### PR TITLE
fix+perf: Benford correlation and entropy features

### DIFF
--- a/functime/feature_extraction/tsfresh.py
+++ b/functime/feature_extraction/tsfresh.py
@@ -64,7 +64,6 @@ def absolute_sum_of_changes(x: TIME_SERIES_T) -> FLOAT_EXPR:
     """
     return x.diff(n=1, null_behavior="drop").abs().sum()
 
-
 def _phis(x: pl.Expr, m: int, N: int, rs: List[float]) -> List[float]:
     n = N - m + 1
     x_runs = [x.slice(i, m) for i in range(n)]
@@ -249,7 +248,7 @@ def benford_correlation(x: TIME_SERIES_T) -> FLOAT_EXPR:
     [4] Newcomb, S. (1881). Note on the frequency of use of the different digits in natural numbers. American Journal of
         mathematics.
     """
-    y = x.abs().cast(pl.Utf8).str.strip_chars_start("0.")
+    y = x.cast(pl.Utf8).str.strip_chars_start("-0.")
     if isinstance(x, pl.Series):
         counts = (
             y.filter(y != "").str.slice(0, 1).cast(


### PR DESCRIPTION
1. Do not approve for now.
2. Fixed a problem in benford_correlation. (x != "") is erroneous because x is numeric. In eager mode, np.corrcoef returns a matrix so we need to extract the coefficient, not return the whole matrix. Also, moving sort after value_counts which gives us another 3-5% perf improvment.
3. Significantly improved perf for permutation entropy by utilizing parallelism provided by pl.concat_list to a greater degree.
4. I have an idea to improve perf of binned_entropy. It is not implemented yet. I will likely work on this this weekend. It is tested on integers and works as fast as Tsfresh. I mentioned in a previous issue that we were about significantly slower and this could bring the performance to the same level. So this would be a big win. The only problem now I am facing is a precision issue when the input column is float, which results in error of scale 1e-5, which can be big sometimes.  

The key idea in (4) is to create the segments by floordiv, instead of using cuts, which does way more computation than needed. 

```
  (x.floordiv((x.max() - x.min())/pl.lit(max_bin) + x.min() )).drop_nulls().value_counts().sort()
  .struct.field("counts")
  .entropy()
```