### PR TITLE
fix: Approx. entropy in eager mode

### DIFF
--- a/functime/feature_extraction/tsfresh.py
+++ b/functime/feature_extraction/tsfresh.py
@@ -76,7 +76,7 @@ def approximate_entropy(
 ) -> float:
     """
     Approximate sample entropies of a time series given multiple filtering levels. 
-    Currently only implemented with pl.Series.
+    This only works for Series input right now.
 
     Parameters
     ----------
@@ -140,7 +140,8 @@ ApEn = approximate_entropy
 
 def augmented_dickey_fuller(x: TIME_SERIES_T, n_lags: int) -> float:
     """
-    Calculates the Augmented Dickey-Fuller (ADF) test statistic.
+    Calculates the Augmented Dickey-Fuller (ADF) test statistic. This only works for 
+    Series input right now.
 
     Parameters
     ----------
@@ -223,7 +224,8 @@ def autocorrelation(x: TIME_SERIES_T, n_lags: int) -> FLOAT_EXPR:
 
 def autoregressive_coefficients(x: TIME_SERIES_T, n_lags: int) -> List[float]:
     """
-    Computes coefficients for an AR(`n_lags`) process.
+    Computes coefficients for an AR(`n_lags`) process. This only works for Series input 
+    right now.
 
     Parameters
     ----------
@@ -669,7 +671,8 @@ def first_location_of_minimum(x: TIME_SERIES_T) -> FLOAT_EXPR:
 
 def fourier_entropy(x: TIME_SERIES_T, n_bins: int = 10) -> float:
     """
-    Calculate the Fourier entropy of a time series.
+    Calculate the Fourier entropy of a time series. This only works for Series input 
+    right now.
 
     Parameters
     ----------
@@ -1364,7 +1367,8 @@ def _into_sequential_chunks(x: pl.Series, m: int) -> np.ndarray:
 # Only works on series
 def sample_entropy(x: TIME_SERIES_T, ratio: float = 0.2) -> FLOAT_EXPR:
     """
-    Calculate the sample entropy of a time series.
+    Calculate the sample entropy of a time series. This only works for Series 
+    input right now.
 
     Parameters
     ----------
@@ -1409,6 +1413,7 @@ def sample_entropy(x: TIME_SERIES_T, ratio: float = 0.2) -> FLOAT_EXPR:
 def spkt_welch_density(x: TIME_SERIES_T, n_coeffs: Optional[int] = None) -> LIST_EXPR:
     '''
     This estimates the cross power spectral density of the time series x at different frequencies.
+    This only works for Series input right now.
 
     Parameters
     ----------

--- a/functime/feature_extraction/tsfresh.py
+++ b/functime/feature_extraction/tsfresh.py
@@ -64,7 +64,6 @@ def absolute_sum_of_changes(x: TIME_SERIES_T) -> FLOAT_EXPR:
     """
     return x.diff(n=1, null_behavior="drop").abs().sum()
 
-
 def _phis(x: pl.Expr, m: int, N: int, rs: List[float]) -> List[float]:
     n = N - m + 1
     x_runs = [x.slice(i, m) for i in range(n)]
@@ -249,7 +248,7 @@ def benford_correlation(x: TIME_SERIES_T) -> FLOAT_EXPR:
     [4] Newcomb, S. (1881). Note on the frequency of use of the different digits in natural numbers. American Journal of
         mathematics.
     """
-    y = x.abs().cast(pl.Utf8).str.strip_chars_start("0.")
+    y = x.cast(pl.Utf8).str.strip_chars_start("-0.")
     if isinstance(x, pl.Series):
         counts = (
             y.filter(y != "").str.slice(0, 1).cast(

--- a/functime/feature_extraction/tsfresh.py
+++ b/functime/feature_extraction/tsfresh.py
@@ -1343,9 +1343,9 @@ def root_mean_square(x: TIME_SERIES_T) -> FLOAT_EXPR:
     float | Expr
     """
     if isinstance(x, pl.Series):
-        return np.sqrt(np.dot(x,x))
+        return np.sqrt(np.dot(x,x) / len(x))
     else:
-        return x.dot(x).sqrt()
+        return (x.dot(x)/x.count()).sqrt()
 
 def _into_sequential_chunks(x: pl.Series, m: int) -> np.ndarray:
     name = x.name

--- a/functime/feature_extraction/tsfresh.py
+++ b/functime/feature_extraction/tsfresh.py
@@ -1054,7 +1054,7 @@ def mean_second_derivative_central(x: pl.Series) -> float:
     -------
     float
     """
-    return (x[-1] - x[-2] - x[1] + x[0]) / (2 * (len(x) - 2))
+    return (x.tail(2).diff(null_behavior="drop") - x.head(2).diff(null_behavior="drop")) / (2*(x.len()- 2))
 
 
 def number_crossings(x: TIME_SERIES_T, crossing_value: float = 0.0) -> FLOAT_EXPR:

--- a/functime/feature_extraction/tsfresh.py
+++ b/functime/feature_extraction/tsfresh.py
@@ -962,7 +962,7 @@ def _get_length_sequences_where(x: TIME_SERIES_T) -> LIST_EXPR:
         If no ones or Trues contained, the list [0] is returned.
     """
     y = x.cast(pl.Int8).rle()
-    return y.filter(x.struct[1] == 1).struct[0]
+    return y.filter(y.struct.field("values") == 1).struct.field("lengths")
 
 
 def longest_strike_above_mean(x: TIME_SERIES_T) -> INT_EXPR:
@@ -1049,7 +1049,7 @@ def mean_n_absolute_max(x: TIME_SERIES_T, n_maxima: int) -> FLOAT_EXPR:
     return x.abs().top_k(n_maxima).mean().cast(pl.Float64)
 
 
-def mean_second_derivative_central(x: pl.Series) -> float:
+def mean_second_derivative_central(x: pl.Series) -> pl.Series:
     """
     Returns the mean value of a central approximation of the second derivative.
 
@@ -1066,7 +1066,7 @@ def mean_second_derivative_central(x: pl.Series) -> float:
 
     Returns
     -------
-    float
+    pl.Series
     """
     return (x.tail(2).diff(null_behavior="drop") - x.head(2).diff(null_behavior="drop")) / (2*(x.len()- 2))
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ dependencies = [
     "kaleido==0.2.1",
     "numpy",
     "plotly",
-    "polars==0.19.2",
+    "polars==0.19.6",
     "pyarrow",
     "pylance",
     "pynndescent==0.5.8",

--- a/tests/test_tsfresh.py
+++ b/tests/test_tsfresh.py
@@ -1,7 +1,7 @@
 import numpy as np
 import polars as pl
 import pytest
-from polars.testing import assert_frame_equal
+from polars.testing import assert_frame_equal, assert_series_equal
 
 # percent_recoccuring_values,
 from functime.feature_extraction.tsfresh import (
@@ -423,14 +423,16 @@ def test_augmented_dickey_fuller(x, param, res):
 @pytest.mark.parametrize(
     "x, res",
     [
-        (pl.Series(range(10)), 0),
-        (pl.Series([1, 3, 5]), 0),
-        (pl.Series([1, 3, 7, -3]), -3),
+        (pl.Series(range(10)), pl.Series([0.0])),
+        (pl.Series([1, 3, 5]), pl.Series([0.0])),
+        (pl.Series([1, 3, 7, -3]), pl.Series([-3.0])),
     ],
 )
 def test_mean_second_derivative_central(x, res):
-    assert mean_second_derivative_central(x) == res
-
+    assert_series_equal(
+        mean_second_derivative_central(x),
+        res
+    )
 # This test needs to be rewritten..
 @pytest.mark.parametrize(
     "x, r, res",

--- a/tests/test_tsfresh.py
+++ b/tests/test_tsfresh.py
@@ -314,6 +314,31 @@ def test_sum_reocurring_values(S, res):
     )
 
 
+@pytest.mark.parametrize("S, res", [
+    ([1, 1, 2, 3, 4], [0.4]),
+    ([1, 1.5, 2, 3], [0]),
+    ([1], [0]),
+    ([1.111, -2.45, 1.111, 2.45], [0.5]),
+    ([], [np.nan])
+])
+def test_percent_reocurring_points(S, res):
+    assert_frame_equal(
+        pl.DataFrame(
+            {"a": S}
+        ).select(
+            percent_reocurring_points(pl.col("a"))
+        ),
+        pl.DataFrame(pl.Series("a", res, dtype=pl.Float64))
+    )
+    assert_frame_equal(
+        pl.LazyFrame(
+            {"a": S}
+        ).select(
+            percent_reocurring_points(pl.col("a"))
+        ).collect(),
+        pl.DataFrame(pl.Series("a", res, dtype=pl.Float64))
+    )
+
 
 @pytest.mark.parametrize("S, n, res", [
     ([0, 5, 2, 3, 0, 1, 2, 3, 4, 5, 4, 3, 2, 1], 1, [3]),

--- a/tests/test_tsfresh.py
+++ b/tests/test_tsfresh.py
@@ -3,6 +3,7 @@ import polars as pl
 import pytest
 from polars.testing import assert_frame_equal
 
+# percent_recoccuring_values,
 from functime.feature_extraction.tsfresh import (
     _get_length_sequences_where,
     benford_correlation,
@@ -10,13 +11,14 @@ from functime.feature_extraction.tsfresh import (
     longest_strike_below_mean,
     mean_n_absolute_max,
     mean_second_derivative_central,
-    percent_recoccuring_values,
     percent_reocurring_points,
     sum_reocurring_points,
     sum_reocurring_values,
     number_peaks,
     symmetry_looking,
     time_reversal_asymmetry_statistic,
+    approximate_entropy,
+    percent_reoccuring_values
 )
 
 np.random.seed(42)
@@ -53,13 +55,13 @@ def test_benford_correlation():
         X_uniform.select(
             benford_correlation(pl.col("a"))
         ),
-        pl.DataFrame({"counts": [1.3891e-16]})
+        pl.DataFrame({"counts": [np.nan]})
     )
     assert_frame_equal(
         X_uniform_lazy.select(
             benford_correlation(pl.col("a"))
         ).collect(),
-        pl.DataFrame({"counts": [1.3891e-16]})
+        pl.DataFrame({"counts": [np.nan]})
     )
     assert_frame_equal(
         X_random.select(
@@ -216,12 +218,12 @@ def test_mean_n_absolute_max_value_error():
     ([1.111, -2.45, 1.111, 2.45], [0.5]),
     ([], [np.nan])
 ])
-def test_percent_reocurring_points(S, res):
+def test_percent_reoccuring_values(S, res):
     assert_frame_equal(
         pl.DataFrame(
             {"a": S}
         ).select(
-            percent_reocurring_points(pl.col("a"))
+            percent_reoccuring_values(pl.col("a"))
         ),
         pl.DataFrame(pl.Series("a", res, dtype=pl.Float64))
     )
@@ -229,7 +231,7 @@ def test_percent_reocurring_points(S, res):
         pl.LazyFrame(
             {"a": S}
         ).select(
-            percent_reocurring_points(pl.col("a"))
+            percent_reoccuring_values(pl.col("a"))
         ).collect(),
         pl.DataFrame(pl.Series("a", res, dtype=pl.Float64))
     )
@@ -241,12 +243,12 @@ def test_percent_reocurring_points(S, res):
     ([1], [0]),
     ([1.111, -2.45, 1.111, 2.45], [1.0 / 3.0])
 ])
-def test_percent_recoccuring_values(S, res):
+def test_percent_reoccuring_values(S, res):
     assert_frame_equal(
         pl.DataFrame(
             {"a": S}
         ).select(
-            percent_recoccuring_values(pl.col("a"))
+            percent_reoccuring_values(pl.col("a"))
         ),
         pl.DataFrame(pl.Series("a", res, dtype=pl.Float64))
     )
@@ -254,7 +256,7 @@ def test_percent_recoccuring_values(S, res):
         pl.LazyFrame(
             {"a": S}
         ).select(
-            percent_recoccuring_values(pl.col("a"))
+            percent_reoccuring_values(pl.col("a"))
         ).collect(),
         pl.DataFrame(pl.Series("a", res, dtype=pl.Float64))
     )
@@ -324,7 +326,7 @@ def test_number_peaks(S, n, res):
         pl.DataFrame(
             {"a": S}
         ).select(
-            number_peaks(pl.col("a"), n=n)
+            number_peaks(pl.col("a"), n).alias("a")
         ),
         pl.DataFrame(pl.Series("a", res, dtype=pl.UInt32))
     )
@@ -332,7 +334,7 @@ def test_number_peaks(S, n, res):
         pl.LazyFrame(
             {"a": S}
         ).select(
-            number_peaks(pl.col("a"), n=n)
+            number_peaks(pl.col("a"), n).alias("a")
         ).collect(),
         pl.DataFrame(pl.Series("a", res, dtype=pl.UInt32))
     )
@@ -429,46 +431,48 @@ def test_augmented_dickey_fuller(x, param, res):
 def test_mean_second_derivative_central(x, res):
     assert mean_second_derivative_central(x) == res
 
-
+# This test needs to be rewritten..
 @pytest.mark.parametrize(
-    "x, param, res",
+    "x, r, res",
     [
         (
             pl.Series([-1, -1, 1, 1]),
-            [dict(r=0.05), dict(r=0.75)],
-            pl.DataFrame(
-                [[0.05, 0.75], [True, True]],
-                schema=["r", "feature_value"],
-                orient="col",
-            ),
+            0.05,
+            True
         ),
         (
-            pl.Series([-1, -1, 1, 1]),
-            [dict(r=0)],
-            pl.DataFrame([[0], [False]], schema=["r", "feature_value"], orient="col"),
+            pl.Series([-2, -1, 0, 1, 1]),
+            0.05,
+            False
         ),
         (
-            pl.Series([-1, -1, -1, -1, 1]),
-            [dict(r=0.05)],
-            pl.DataFrame(
-                [[0.05], [False]], schema=["r", "feature_value"], orient="col"
-            ),
-        ),
-        (
-            pl.Series([-2, -2, -2, -1, -1, -1]),
-            [dict(r=0.05)],
-            pl.DataFrame([[0.05], [True]], schema=["r", "feature_value"], orient="col"),
-        ),
-        (
-            pl.Series([-0.9, -0.900001]),
-            [dict(r=0.05)],
-            pl.DataFrame([[0.05], [True]], schema=["r", "feature_value"], orient="col"),
+            pl.Series([-2, -1, 0, 1, 1]),
+            0.1,
+            True
         ),
     ],
 )
-def test_symmetry_looking(x, param, res):
-    assert_frame_equal(symmetry_looking(x, param), res)
+def test_symmetry_looking(x, r, res):
+    ans = symmetry_looking(x, r)
+    assert ans == res
 
+    df = x.to_frame()
+    assert_frame_equal(
+        df.select(
+            symmetry_looking(pl.col(x.name), ratio=r)
+        ),
+        pl.DataFrame({x.name:[res]})
+    )
+
+# The first test here is take from wikipedia
+@pytest.mark.parametrize(
+    "x, param, res", [
+        (pl.Series([85, 80, 89] * 17), {"m":2, "r":3, "scale":False}, 1.099654110658932e-05)
+    ]
+)
+def test_approximate_entropy(x, param, res):
+    ans = approximate_entropy(x, param["m"], param["r"], param["scale"])
+    assert ans == res
 
 @pytest.mark.parametrize(
     "x, lag, res", [(pl.Series([1] * 10), 0, 0), (pl.Series([1, 2, -3, 4]), 1, -10)]


### PR DESCRIPTION
1. Fixed approximate_entropy. It works in eager mode now and is a lot faster than tsfresh
2. Reverted .count() back to .len(), because Series do not have .count(). I guess the 1-level of indirection is negligible.
3. Improved perf for absolute_maximum by 30-50%, and potentially lowered the memory usage by a lot. The is done by noticing that the max of abs(x) is either abs(x.max()) or abs(x.min()).  So we do not need to create an intermediate series x.abs(), which saves a lot of memory. The speed up also comes from the fact that we can use pl.max_horizontal to parallelize the computation for abs(x.max()) and abs(x.min()).
4. Fixed some test cases, but not all. Longest_strike's test cases are still failing. 
5. Added Heiner's change on mean_second_derivative_central which makes it work for both Expr and Series.
6. Improved perf for cid_ce and root_mean_square by using .dot. The reason is again due to the small memory footprint of .dot. 
7. Improved last/first_loc_of_min/max by noticing a quirk. The speed up is due to a performance regression on arg_max, and therefore the alternative method is now faster. I will keep this in mind and revert it once the issue with arg_max is solved.
8. Slightly improved perf for autoregressive_coefficients by generating the data matrix faster using Polars instead of NumPy vstack.

![image](https://github.com/neocortexdb/functime/assets/72534736/be6bedf7-70fa-4d1e-867d-4a138cbff6c5)

![image](https://github.com/neocortexdb/functime/assets/72534736/be2b2824-209c-4a0b-9eba-eac488e72609)

![image](https://github.com/neocortexdb/functime/assets/72534736/815daf75-f574-454a-ba4d-c3fd875dc774)
