### PR TITLE
fixed autocorr + Lempel Ziv Complexity + Some failing tests

### DIFF
--- a/functime/feature_extraction/tsfresh.py
+++ b/functime/feature_extraction/tsfresh.py
@@ -776,38 +776,54 @@ def last_location_of_minimum(x: TIME_SERIES_T) -> FLOAT_EXPR:
     return 1.0 - x.reverse().arg_min()/x.len()
 
 
-def lempel_ziv_complexity(x: pl.Series, n_bins: int) -> List[float]:
+def lempel_ziv_complexity(x: TIME_SERIES_T, value:Union[float, pl.Expr]) -> FLOAT_EXPR:
     """
-    Calculate a complexity estimate based on the Lempel-Ziv compression algorithm.
+    Calculate a complexity estimate based on the Lempel-Ziv compression algorithm. The
+    implementation here is currently taken from Lilian Besson. See the reference section 
+    below. Instead of return the complexity value, we return a ratio w.r.t the length of
+    the input series.
 
     Parameters
     ----------
     x : pl.Expr | pl.Series
         Input time-series.
-    n_bins : int
-        An integer specifying the number of bins to use for discretizing the time series.
+    value : float | pl.Expr
+        Either a number, or an expression representing a comparable quantity. If x > value,
+        then it will be binarized as 1 and 0 otherwise. If x is eager, then value must also
+        be eager as well.
 
     Returns
     -------
-    list of float
+    float
+
+    Reference
+    ---------
+    https://github.com/Naereen/Lempel-Ziv_Complexity/tree/master
+    https://en.wikipedia.org/wiki/Lempel%E2%80%93Ziv_complexity
     """
-    complexities = []
-    seq = x.search_sorted(
-        element=np.linspace(x.min(), x.max(), n_bins + 1)[1:], side="left"
-    ).to_numpy()
-    sub_strs = set()
-    n = x.len()
-    ind, inc = 0, 1
-    while not ind + inc > n:
-        sub_str = seq[ind : ind + inc]
-        if sub_str in sub_strs:
-            inc += 1
-        else:
-            sub_strs.add(sub_str)
-            ind += inc
-            inc = 1
-        complexities.append(len(sub_str) / n)
-    return complexities
+    if isinstance(x, pl.Series):
+        if isinstance(value, pl.Expr):
+            raise ValueError("Input `value` must be a number when input x is a series.")
+
+        binary_seq = b"".join((x > value).cast(pl.Binary))
+        sub_strings = set()
+        n = len(binary_seq)
+        ind = 0
+        inc = 1
+        while True:
+            if ind + inc > len(binary_seq):
+                break
+            sub_str = binary_seq[ind : ind + inc]
+            if sub_str in sub_strings:
+                inc += 1
+            else:
+                sub_strings.add(sub_str)
+                ind += inc
+                inc = 1
+
+        return len(sub_strings) / n
+    else:
+        return NotImplemented
 
 
 def linear_trend(x: TIME_SERIES_T) -> MAP_EXPR:

--- a/functime/feature_extraction/tsfresh.py
+++ b/functime/feature_extraction/tsfresh.py
@@ -776,7 +776,7 @@ def last_location_of_minimum(x: TIME_SERIES_T) -> FLOAT_EXPR:
     return 1.0 - x.reverse().arg_min()/x.len()
 
 
-def lempel_ziv_complexity(x: TIME_SERIES_T, value:Union[float, pl.Expr]) -> FLOAT_EXPR:
+def lempel_ziv_complexity(x: TIME_SERIES_T, threshold:Union[float, pl.Expr]) -> FLOAT_EXPR:
     """
     Calculate a complexity estimate based on the Lempel-Ziv compression algorithm. The
     implementation here is currently taken from Lilian Besson. See the reference section 

--- a/functime/feature_extraction/tsfresh.py
+++ b/functime/feature_extraction/tsfresh.py
@@ -203,8 +203,8 @@ def autocorrelation(x: TIME_SERIES_T, n_lags: int) -> FLOAT_EXPR:
     mean = x.mean()
     var = x.var(ddof=0)
     range_ = x.len() - n_lags
-    y1 = x.slice(0, length=range_) - mean
-    y2 = x.slice(n_lags, length=None) - mean 
+    y1 = x - mean
+    y2 = x.shift(-n_lags) - mean
     return y1.dot(y2) / (var * range_)
 
 

--- a/functime/feature_extraction/tsfresh.py
+++ b/functime/feature_extraction/tsfresh.py
@@ -805,7 +805,7 @@ def lempel_ziv_complexity(x: TIME_SERIES_T, value:Union[float, pl.Expr]) -> FLOA
         if isinstance(value, pl.Expr):
             raise ValueError("Input `value` must be a number when input x is a series.")
 
-        binary_seq = b"".join((x > value).cast(pl.Binary))
+        binary_seq = b"".join((x > threshold).cast(pl.Binary))
         sub_strings = set()
         n = len(binary_seq)
         ind = 0

--- a/functime/feature_extraction/tsfresh.py
+++ b/functime/feature_extraction/tsfresh.py
@@ -787,7 +787,7 @@ def lempel_ziv_complexity(x: TIME_SERIES_T, value:Union[float, pl.Expr]) -> FLOA
     ----------
     x : pl.Expr | pl.Series
         Input time-series.
-    value : float | pl.Expr
+    threshold: float | pl.Expr
         Either a number, or an expression representing a comparable quantity. If x > value,
         then it will be binarized as 1 and 0 otherwise. If x is eager, then value must also
         be eager as well.

--- a/tests/test_tsfresh.py
+++ b/tests/test_tsfresh.py
@@ -17,7 +17,8 @@ from functime.feature_extraction.tsfresh import (
     symmetry_looking,
     time_reversal_asymmetry_statistic,
     approximate_entropy,
-    percent_reoccuring_values
+    percent_reoccuring_values,
+    lempel_ziv_complexity
 )
 
 np.random.seed(42)
@@ -473,3 +474,13 @@ def test_approximate_entropy(x, param, res):
 )
 def test_time_reversal_asymmetry_statistic(x, lag, res):
     assert time_reversal_asymmetry_statistic(x, lag) == res
+
+
+
+def test_lempel_ziv_complexity():
+    a = pl.Series([1,0,0,1,1,1,1,0,1,1,0,0,0,0,1,0])
+    assert lempel_ziv_complexity(a, value = 0) * len(a) == 8
+    a = pl.Series([1,0,0,1,1,1,1,0,1,1,0,0,0,0,1,0,0,0,0,0,1,0])
+    assert lempel_ziv_complexity(a, value = 0) * len(a) == 9
+    a = pl.Series([1,0,0,1,1,1,1,0,1,1,0,0,0,0,1,0,0,0,0,0,1,0,1,0])
+    assert lempel_ziv_complexity(a, value = 0) * len(a) == 10

--- a/tests/test_tsfresh.py
+++ b/tests/test_tsfresh.py
@@ -241,7 +241,7 @@ def test_sum_reocurring_points(S, res):
         pl.DataFrame(
             {"a": S}
         ).select(
-            sum_reocurring_points(pl.col("a"))
+            sum_reocurring_points(pl.col("a")).cast(pl.Float64)
         ),
         pl.DataFrame(pl.Series("a", res, dtype=pl.Float64))
     )
@@ -249,7 +249,7 @@ def test_sum_reocurring_points(S, res):
         pl.LazyFrame(
             {"a": S}
         ).select(
-            sum_reocurring_points(pl.col("a"))
+            sum_reocurring_points(pl.col("a")).cast(pl.Float64)
         ).collect(),
         pl.DataFrame(pl.Series("a", res, dtype=pl.Float64))
     )
@@ -267,7 +267,7 @@ def test_sum_reocurring_values(S, res):
         pl.DataFrame(
             {"a": S}
         ).select(
-            sum_reocurring_values(pl.col("a"))
+            sum_reocurring_values(pl.col("a")).cast(pl.Float64)
         ),
         pl.DataFrame(pl.Series("a", res, dtype=pl.Float64))
     )
@@ -275,7 +275,7 @@ def test_sum_reocurring_values(S, res):
         pl.LazyFrame(
             {"a": S}
         ).select(
-            sum_reocurring_values(pl.col("a"))
+            sum_reocurring_values(pl.col("a")).cast(pl.Float64)
         ).collect(),
         pl.DataFrame(pl.Series("a", res, dtype=pl.Float64))
     )


### PR DESCRIPTION
The issue is that in lazy Polars, slice behaves differently. The problem lies somewhere in its length calculation. Try running the following code, which will give us error in the lazy case. Since in our original code, we are just returning one expression at the end, the error didn't occur, but something inside was wrong. You can see the issue here: https://github.com/pola-rs/polars/issues/11594#issue-1931924184

```
df = pl.DataFrame({
    "a": [1,2,1,2,1,2],
    "b": [None, None, 1,1,1,1]
})

df.select(
    pl.col("a").slice(offset = 0, length=pl.count() - 2).alias("1"),
    pl.col("a").slice(offset = 1, length=pl.count() - 2).alias("2")
)

df.lazy().select(
    pl.col("a").slice(offset = 0, length=pl.count() - 2).alias("1"),
    pl.col("a").slice(offset = 1, length=pl.count() - 2).alias("2")
).collect()
```

I fixed the bug by reverting back to using shift, which will be slower than .head() / tail() / slice(), but will avoid using slice for now. We actually do not need to drop nulls after shifting, because dot product will null will just result in 0. 