### PR TITLE
Additional Features, Fixed Energy Ratios

### DIFF
--- a/functime/feature_extraction/tsfresh.py
+++ b/functime/feature_extraction/tsfresh.py
@@ -549,6 +549,7 @@ def cwt_coefficients(
 def energy_ratios(x: TIME_SERIES_T, n_chunks: int = 10) -> LIST_EXPR:
     """
     Calculates sum of squares over the whole series for `n_chunks` equally segmented parts of the time-series.
+    E.g. if n_chunks = 10, values are [0, 1, 2, 3, .. , 999], the first chunk will be [0, .. , 99].
 
     Parameters
     ----------
@@ -563,10 +564,15 @@ def energy_ratios(x: TIME_SERIES_T, n_chunks: int = 10) -> LIST_EXPR:
     """
     # Unlike Tsfresh,
     # We calculate all 1,2,3,...,n_chunk at once
-    seg_sum = x.pow(2).reshape((n_chunks, -1)).list.sum()
     if isinstance(x, pl.Series):
+        y = x.pow(2).extend_constant(0, n_chunks - (x.len() % n_chunks))
+        seg_sum = y.reshape((n_chunks, y.len()//n_chunks)).list.sum()
         return (seg_sum / seg_sum.sum()).to_list()
     else:
+        y = x.pow(2).append(
+            pl.lit(0).repeat_by(pl.lit(n_chunks) - x.count().mod(n_chunks))
+        )
+        seg_sum = y.reshape((n_chunks, -1)).list.sum()
         return (seg_sum / seg_sum.sum()).implode()
 
 
@@ -884,8 +890,11 @@ def longest_strike_above_mean(x: TIME_SERIES_T) -> INT_EXPR:
     -------
     int | Expr
     """
-    y = (x.cast(pl.Float64) > x.mean()).cast(pl.UInt8).rle()
-    result = y.filter(y.struct.field("values")==1).struct.field("lengths").max()
+    if isinstance(x, pl.Series):
+        y = (x.cast(pl.Float64) > x.mean()).rle()
+    else:
+        y = (x > x.mean()).rle()
+    result = y.filter(y.struct.field("values")).struct.field("lengths").max()
     if isinstance(x, pl.Series):
         return 0 if result is None else result
     else: # fill null only works with expression
@@ -905,8 +914,11 @@ def longest_strike_below_mean(x: TIME_SERIES_T) -> INT_EXPR:
     -------
     int | Expr
     """
-    y = (x.cast(pl.Float64) < x.mean()).cast(pl.UInt8).rle()
-    result = y.filter(y.struct.field("values")==1).struct.field("lengths").max()
+    if isinstance(x, pl.Series):
+        y = (x.cast(pl.Float64) < x.mean()).rle()
+    else:
+        y = (x < x.mean()).rle()
+    result = y.filter(y.struct.field("values")).struct.field("lengths").max()
     if isinstance(x, pl.Series):
         return 0 if result is None else result
     else: # fill null only works with expression
@@ -926,6 +938,36 @@ def mean_abs_change(x: TIME_SERIES_T) -> FLOAT_EXPR:
     float | Expr
     """
     return x.diff(null_behavior="drop").abs().mean()
+
+def max_change(x: TIME_SERIES_T) -> FLOAT_INT_EXPR:
+    """
+    Compute the maximum change from X_t to X_t+1.
+
+    Parameters
+    ----------
+    x : pl.Expr | pl.Series
+        A single time-series.
+
+    Returns
+    -------
+    float | Expr
+    """
+    return x.diff().max()
+
+def max_abs_change(x: TIME_SERIES_T) -> FLOAT_INT_EXPR:
+    """
+    Compute the maximum absolute change from X_t to X_t+1.
+
+    Parameters
+    ----------
+    x : pl.Expr | pl.Series
+        A single time-series.
+
+    Returns
+    -------
+    float | Expr
+    """
+    return absolute_maximum(x.diff(null_behavior="drop"))
 
 def mean_change(x: TIME_SERIES_T) -> FLOAT_EXPR:
     """
@@ -1467,7 +1509,7 @@ def var_gt_std(x: TIME_SERIES_T, ddof: int = 1) -> BOOL_EXPR:
     x : pl.Expr | pl.Series
         Input time series.
     ddof : int
-        Delta Degrees of Freedom used when computing var/std.
+        Delta Degrees of Freedom used when computing var.
 
     Returns
     -------
@@ -1478,7 +1520,7 @@ def var_gt_std(x: TIME_SERIES_T, ddof: int = 1) -> BOOL_EXPR:
 
 def harmonic_mean(x: TIME_SERIES_T) -> FLOAT_EXPR:
     """
-    Returns the harmonic mean of the expression
+    Returns the harmonic mean of the of the time series.
 
     Parameters
     ----------
@@ -1490,6 +1532,161 @@ def harmonic_mean(x: TIME_SERIES_T) -> FLOAT_EXPR:
     float | Expr
     """
     return x.len() / (pl.lit(1.0) / x).sum()
+
+def range_over_mean(x:TIME_SERIES_T) -> FLOAT_EXPR:
+    '''
+    Returns the range (max - min) over mean of the time series.
+
+    Parameters
+    ----------
+    x : pl.Expr | pl.Series
+        Input time series.
+
+    Returns
+    -------
+    float | Expr
+    '''
+    return (x.max() - x.min()) / x.mean()
+
+def range_change(x:TIME_SERIES_T, percentage:bool = True) -> FLOAT_EXPR:
+    '''
+    Returns the maximum value range. If percentage is true, will compute 
+    (max - min) / min, which only makes sense when x is always positive.
+
+    Parameters
+    ----------
+    x : pl.Expr | pl.Series
+        Input time series.
+
+    Returns
+    -------
+    float | Expr
+    '''
+    if percentage:
+        return (x.max() - x.min()) / x.min()
+    else:
+        return x.max() - x.min()
+
+
+def longest_winning_streak(x:TIME_SERIES_T):
+    '''
+    Returns the longest winning streak of the time series. A win is counted when
+    (x_t+1 - x_t) >= 0
+    
+    Parameters
+    ----------
+    x : pl.Expr | pl.Series
+        Input time series.
+
+    Returns
+    -------
+    float | Expr
+    '''
+    y = (x.diff() >= 0).rle()
+    return y.filter(y.struct.field("values")).struct.field("lengths").max()
+
+
+def longest_losing_streak(x:TIME_SERIES_T):
+    '''
+    Returns the longest losing streak of the time series. A loss is counted when
+    (x_t+1 - x_t) <= 0
+
+    Parameters
+    ----------
+    x : pl.Expr | pl.Series
+        Input time series.
+
+    Returns
+    -------
+    float | Expr
+    '''
+    y = (x.diff() <= 0).rle()
+    return y.filter(y.struct.field("values")).struct.field("lengths").max()
+
+def streak_length_stats(x:TIME_SERIES_T, above:bool, threshold: float) -> MAP_EXPR:
+    '''
+    Returns some statistics of the length of the streaks of the time series. 
+
+    The statistics include: min length, max length, average length, std of length,
+    10-percentile length, median length, 90-percentile length, and mode of the length. If input is Series,
+    a dictionary will be returned. If input is an expression, the expression will evaluate to a struct
+    with the fields ordered by the statistics.
+
+    Parameters
+    ----------
+    x : pl.Expr | pl.Series
+        Input time series.
+    above: bool
+        Above (>=) or below (<=) the given threshold
+    threshold
+        The threshold for the change (x_t+1 - x_t) to be counted
+
+    Returns
+    -------
+    float | Expr
+    '''
+    if above:
+        y = (x.diff() >= threshold).rle()
+    else:
+        y = (x.diff() <= threshold).rle()
+
+    y = y.filter(y.struct.field("values")).struct.field("lengths")
+    if isinstance(x, pl.Series):
+        return {
+            "min": y.min(),
+            "max": y.max(),
+            "mean": y.mean(),
+            "std": y.std(),
+            "10-percentile": y.quantile(0.1),
+            "median": y.median(),
+            "90-percentile": y.quantile(0.9),
+            "mode": y.mode()[0]
+        }
+    else:
+        return pl.struct(
+            y.min().alias("min"),
+            y.max().alias("max"),
+            y.mean().alias("mean"),
+            y.std().alias("std"),
+            y.quantile(0.1).alias("10-percentile"),
+            y.median().alias("median"),
+            y.quantile(0.9).alias("90-percentile"),
+            y.mode().first().alias("mode")
+        )
+
+def longest_streak_above(x:TIME_SERIES_T, threshold:float):
+    '''
+    Returns the longest streak of changes >= threshold of the time series. A change
+    is counted when (x_t+1 - x_t) >= threshold
+
+    Parameters
+    ----------
+    x : pl.Expr | pl.Series
+        Input time series.
+
+    Returns
+    -------
+    float | Expr
+    '''
+    y = (x.diff() >= threshold).rle()
+    return y.filter(y.struct.field("values")).struct.field("lengths").max()
+
+def longest_streak_below(x:TIME_SERIES_T, threshold:float):
+    '''
+    Returns the longest streak of changes <= threshold of the time series. A change
+    is counted when (x_t+1 - x_t) <= threshold
+
+    Parameters
+    ----------
+    x : pl.Expr | pl.Series
+        Input time series.
+
+    Returns
+    -------
+    float | Expr
+    '''
+    y = (x.diff() <= threshold).rle()
+    return y.filter(y.struct.field("values")).struct.field("lengths").max()
 
 
 # FFT Features

--- a/functime/feature_extraction/tsfresh.py
+++ b/functime/feature_extraction/tsfresh.py
@@ -876,7 +876,7 @@ def linear_trend(x: TIME_SERIES_T) -> MAP_EXPR:
             beta.alias("slope"), alpha.alias("intercept"), resid.dot(resid).alias("rss")
         )
 
-def longest_strike_above_mean(x: TIME_SERIES_T) -> INT_EXPR:
+def longest_streak_above_mean(x: TIME_SERIES_T) -> INT_EXPR:
     """
     Returns the length of the longest consecutive subsequence in x that is greater than the mean of x.
     If all values in x are null, 0 will be returned.
@@ -900,7 +900,7 @@ def longest_strike_above_mean(x: TIME_SERIES_T) -> INT_EXPR:
     else: # fill null only works with expression
         return result.fill_null(0).cast(pl.UInt64)
 
-def longest_strike_below_mean(x: TIME_SERIES_T) -> INT_EXPR:
+def longest_streak_below_mean(x: TIME_SERIES_T) -> INT_EXPR:
     """
     Returns the length of the longest consecutive subsequence in x that is smaller than the mean of x.
     If all values in x are null, 0 will be returned.

--- a/tests/test_tsfresh.py
+++ b/tests/test_tsfresh.py
@@ -21,8 +21,8 @@ from functime.feature_extraction.tsfresh import (
     count_above_mean,
     count_below,
     count_below_mean,
-    longest_strike_above_mean,
-    longest_strike_below_mean,
+    longest_streak_above_mean,
+    longest_streak_below_mean,
     mean_n_absolute_max,
     mean_second_derivative_central,
     percent_reocurring_points,
@@ -496,12 +496,12 @@ def test_benford_correlation():
     ([1, 1, 1], [0]),
     ([], [0])
 ])
-def test_longest_strike_below_mean(S, res):
+def test_longest_streak_below_mean(S, res):
     assert_frame_equal(
         pl.DataFrame(
             {"a": S}
         ).select(
-            longest_strike_below_mean(pl.col("a")).alias("lengths")
+            longest_streak_below_mean(pl.col("a")).alias("lengths")
         ),
         pl.DataFrame(pl.Series("lengths", res, dtype=pl.UInt64))
     )
@@ -509,7 +509,7 @@ def test_longest_strike_below_mean(S, res):
         pl.LazyFrame(
             {"a": S}
         ).select(
-            longest_strike_below_mean(pl.col("a")).alias("lengths")
+            longest_streak_below_mean(pl.col("a")).alias("lengths")
         ).collect(),
         pl.DataFrame(pl.Series("lengths", res, dtype=pl.UInt64))
     )
@@ -523,12 +523,12 @@ def test_longest_strike_below_mean(S, res):
     ([1, 1, 1], [0]),
     ([], [0])
 ])
-def test_longest_strike_above_mean(S, res):
+def test_longest_streak_above_mean(S, res):
     assert_frame_equal(
         pl.DataFrame(
             {"a": S}
         ).select(
-            longest_strike_above_mean(pl.col("a")).alias("lengths")
+            longest_streak_above_mean(pl.col("a")).alias("lengths")
         ),
         pl.DataFrame(pl.Series("lengths", res, dtype=pl.UInt64))
     )
@@ -536,7 +536,7 @@ def test_longest_strike_above_mean(S, res):
         pl.LazyFrame(
             {"a": S}
         ).select(
-            longest_strike_above_mean(pl.col("a")).alias("lengths")
+            longest_streak_above_mean(pl.col("a")).alias("lengths")
         ).collect(),
         pl.DataFrame(pl.Series("lengths", res, dtype=pl.UInt64))
     )


### PR DESCRIPTION
Additional Features:

- range_over_mean: (max - min) / mean
- range_change: Returns the maximum value range. If percentage is true, will compute (max - min) / min, which only makes sense when x is always positive.
- longest_winning_streak: Returns the longest winning streak of the time series. A win is counted when (x_t+1 - x_t) >= 0
- longest_losing_streak: similar
- streak_length_stats: stats about the streaks.
- longest_streak_above: similar, but you supply the threshold
- longest_streak_below: similar, but you supply the threshold
- max_abs_change: Compute the maximum absolute change from X_t to X_t+1.


Other fixes:
1. Fixed a bug in energy_ratio pointed out by Mathieu
2. Changed "strike" to "streak" which is a more accurate English word 