### PR TITLE
refactor(version): add `__version__` to `__init__.py`

### DIFF
--- a/functime/__init__.py
+++ b/functime/__init__.py
@@ -1,1 +1,3 @@
 "functime: Time-series machine learning at scale."
+
+__version__ = "0.8.2"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,9 +4,9 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "functime"
-version = "0.8.2"
 description = "Time-series machine learning at scale."
 readme = "README.md"
+dynamic = ["version"]
 requires-python = ">=3.8"
 authors = [
     { name = "functime Team", email = "team@functime.ai" },
@@ -69,6 +69,9 @@ doc = ["mkdocs", "mkdocs-material", "mkdocstrings-python", "mkdocs-jupyter"]
 
 [tool.setuptools.packages.find]
 include = ["functime", "functime.*"]
+
+[tool.setuptools.dynamic]
+version = {attr = "functime.__version__"}
 
 [tool.isort]
 profile = "black"


### PR DESCRIPTION
The version is only specified in `__init__.py` and is automatically fetched by setuptools, see [here](https://setuptools.pypa.io/en/latest/userguide/pyproject_config.html#dynamic-metadata).

In other words: if this is merged, then we would have to change the version straight form `functime.__init__.py:__version__` and not from `pyproject.toml`.

Why would we want to approve this? So people can do `print(functime.__version__)` or - in other words - have a way to print functime's version from Python.

Closes #73.