### PR TITLE
perf+test: More tsfresh updates

### DIFF
--- a/functime/feature_extraction/feature_extractor.py
+++ b/functime/feature_extraction/feature_extractor.py
@@ -2,9 +2,13 @@ import math
 import polars as pl
 import functime.feature_extraction.tsfresh as f
 from polars.type_aliases import ClosedInterval
+# from polars.type_aliases import IntoExpr
+from polars.utils.udfs import _get_shared_lib_location
+
+lib = _get_shared_lib_location(__file__)
 
 @pl.api.register_expr_namespace("ts")
-class FeatureLibrary:
+class FeatureExtractor:
     def __init__(self, expr: pl.Expr):
         self._expr = expr
 
@@ -340,6 +344,27 @@ class FeatureLibrary:
         An expression of the output
         """
         return f.last_location_of_minimum(self._expr)
+
+    # def lempel_ziv_complexity(self, threshold:float, as_ratio:bool=True) -> pl.Expr:
+    #     """
+    #     Returns the Lempel Ziv Complexity. This will binarize the function and if value > threshold,
+    #     this the binarized value will be 1 and otherwise 0. Null will be treated as 0s in the binarization.
+
+    #     Parameters
+    #     ----------
+    #     thrshold
+    #         A python literal or a Polars Expression to compare with
+    #     as_ratio
+    #         If true, return the complexity divided length of the sequence
+    #     """
+    #     out = (self._expr > threshold)._register_plugin(
+    #         lib=lib,
+    #         symbol="pl_lempel_ziv_complexity",
+    #         is_elementwise=True,
+    #     )
+    #     if as_ratio:
+    #         return out / self._expr.len()
+    #     return out
 
     def linear_trend(self) -> pl.Expr:
         """

--- a/functime/feature_extraction/feature_extractor.py
+++ b/functime/feature_extraction/feature_extractor.py
@@ -3,9 +3,9 @@ import polars as pl
 import functime.feature_extraction.tsfresh as f
 from polars.type_aliases import ClosedInterval
 # from polars.type_aliases import IntoExpr
-from polars.utils.udfs import _get_shared_lib_location
+# from polars.utils.udfs import _get_shared_lib_location
 
-lib = _get_shared_lib_location(__file__)
+# lib = _get_shared_lib_location(__file__)
 
 @pl.api.register_expr_namespace("ts")
 class FeatureExtractor:

--- a/functime/ts_feature_library.py
+++ b/functime/ts_feature_library.py
@@ -89,7 +89,8 @@ class FeatureLibrary:
 
     def binned_entropy(self, bin_count: int = 10) -> pl.Expr:
         """
-        Calculates the entropy of a binned histogram for a given time series.
+        Calculates the entropy of a binned histogram for a given time series. It is highly recommended
+        that you impute the time series before calling this.
 
         Parameters
         ----------
@@ -547,15 +548,17 @@ class FeatureLibrary:
         base: float = math.e,
     ) -> pl.Expr:
         """
-        Computes permutation entropy.
+        Computes permutation entropy. It is recommended that users should impute the time series 
+        before calling this.
 
         Parameters
         ----------
         tau : int
             The embedding time delay which controls the number of time periods between elements
-            of each of the new column vectors.
+            of each of the new column vectors. The recommended value is 1.
         n_dims : int, > 1
-            The embedding dimension which controls the length of each of the new column vectors
+            The embedding dimension which controls the length of each of the new column vectors. The
+            recommended range is 3-7.
         base : float
             The base for log in the entropy computation
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ dependencies = [
     "flaml>=2.0.2,<3",
     "holidays",
     "numpy",
-    "polars>=0.19.8,<1",
+    "polars>=0.19.11",
     "scikit-learn>=1.2.2,<2",
     "scipy",
     "tqdm",
@@ -98,6 +98,9 @@ ignore = [
     "B905", # `zip()` without an explicit `strict=` parameter
 ]
 
+[tool.ruff.pyupgrade]
+# Preserve types, even if a file imports `from __future__ import annotations`.
+keep-runtime-typing = true
 
 [tool.maturin]
 module-name = "functime._functime_rust"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -102,6 +102,8 @@ ignore = [
 # Preserve types, even if a file imports `from __future__ import annotations`.
 keep-runtime-typing = true
 
+
+
 [tool.maturin]
 module-name = "functime._functime_rust"
 features = ["pyo3/extension-module"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -97,3 +97,8 @@ ignore = [
     "B008", # do not perform function calls in argument defaults
     "B905", # `zip()` without an explicit `strict=` parameter
 ]
+
+
+[tool.maturin]
+module-name = "functime._functime_rust"
+features = ["pyo3/extension-module"]

--- a/src/feature_extraction/feature_extractor.rs
+++ b/src/feature_extraction/feature_extractor.rs
@@ -1,0 +1,39 @@
+use pyo3::prelude::*;
+use pyo3_polars::{derive::polars_expr, export::polars_core::{series::Series, prelude::{*}}};
+use std::collections::HashSet;
+
+#[pyfunction]
+pub fn rs_lempel_ziv_complexity(
+    s: &[u8]
+) -> usize {
+
+    let mut ind:usize = 0;
+    let mut inc:usize = 1;
+
+    let mut sub_strings: HashSet<&[u8]> = HashSet::new();
+    while ind + inc <= s.len() {
+        let subseq: &[u8] = &s[ind..ind+inc];
+        if sub_strings.contains(subseq) {
+            inc += 1;
+        } else {
+            sub_strings.insert(subseq);
+            ind += inc;
+            inc = 1;
+        }
+    }
+    sub_strings.len()
+}
+
+// #[polars_expr(output_type=UInt32)]
+// fn pl_lempel_ziv_complexity(inputs: &[Series]) -> PolarsResult<Series>  {
+    
+//     let input: &Series = &inputs[0];
+//     let name = input.name();
+//     let input = input.bool()?;
+//     let bools: Vec<u8> = input.into_iter().map(
+//         |op_b| (op_b.unwrap_or(false) as u8)
+//     ).collect();
+//     let c:usize = rs_lempel_ziv_complexity(&bools);
+//     Ok(Series::new(name, [c as u32]))
+
+// }

--- a/src/feature_extraction/mod.rs
+++ b/src/feature_extraction/mod.rs
@@ -1,0 +1,1 @@
+pub mod feature_extractor;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,1 +1,11 @@
 use pyo3::prelude::*;
+
+mod feature_extraction;
+use feature_extraction::feature_extractor::rs_lempel_ziv_complexity;
+
+#[pymodule]
+fn _functime_rust(_py: Python, m: &PyModule) -> PyResult<()> {
+
+    m.add_function(wrap_pyfunction!(rs_lempel_ziv_complexity, m)?)?;
+    Ok(())
+}

--- a/tests/test_tsfresh.py
+++ b/tests/test_tsfresh.py
@@ -109,23 +109,25 @@ def test_mean_abs_change(S, res, k):
         ([-1, 1.3, 5.3, 4.5], [11 / 6], {}),
         ([-1, 1, 2, float("inf")], [float("inf")], {}),
         ([-1, 1, 2, -float("inf")], [-float("inf")], {}),
-        ([], [None], {"check_dtype": False}),
+        ([1], [0], {"check_dtype": False}),
+        ([], [], {"check_dtype": False}),
     ],
 )
 def test_mean_change(S, res, k):
-    assert_series_equal(
-        pl.Series("a", [mean_change(pl.Series("a", S))]),
-        pl.Series("a", res, dtype=pl.Float64),
-        **k,
-    )
+    # if len(res) == 0:
+    if len(res) == 0:
+        assert mean_change(pl.Series(S)) is None
+    else:
+        assert mean_change(pl.Series(S)) == res[0]
+
     assert_frame_equal(
         pl.DataFrame({"a": S}).select(mean_change(pl.col("a"))),
         pl.DataFrame(pl.Series("a", res, dtype=pl.Float64)),
         **k,
     )
     assert_frame_equal(
-        pl.LazyFrame({"a": S}).select(mean_change(pl.col("a"))).collect(),
-        pl.DataFrame(pl.Series("a", res, dtype=pl.Float64)),
+        pl.LazyFrame({"a": S}).lazy().select(mean_change(pl.col("a"))).collect(),
+        pl.DataFrame({"a":pl.Series("a", res, dtype=pl.Float64)}),
         **k,
     )
 

--- a/tests/test_tsfresh.py
+++ b/tests/test_tsfresh.py
@@ -1187,16 +1187,33 @@ def test_augmented_dickey_fuller(x, param, res):
 @pytest.mark.parametrize(
     "x, res",
     [
-        (pl.Series(range(10)), pl.Series([0.0])),
-        (pl.Series([1, 3, 5]), pl.Series([0.0])),
-        (pl.Series([1, 3, 7, -3]), pl.Series([-3.0])),
+        (pl.Series(range(10)), 0.0),
+        (pl.Series([1, 3, 5]), 0.0),
+        (pl.Series([1, 3, 7, -3]),-3.0),
     ],
 )
 def test_mean_second_derivative_central(x, res):
-    assert_series_equal(
-        mean_second_derivative_central(x),
-        res
+
+    assert mean_second_derivative_central(x) == res
+    df = x.to_frame()
+    assert_frame_equal(
+        df.select(
+            mean_second_derivative_central(pl.col(x.name)).alias("1")
+        ),
+        pl.DataFrame({
+            "1": pl.Series([res])
+        })
     )
+    assert_frame_equal(
+        df.lazy().select(
+            mean_second_derivative_central(pl.col(x.name)).alias("1")
+        ).collect(),
+        pl.DataFrame({
+            "1": pl.Series([res])
+        })
+    )
+
+
 # This test needs to be rewritten..
 @pytest.mark.parametrize(
     "x, r, res",


### PR DESCRIPTION
Please do not approve until https://github.com/pola-rs/polars/issues/11736 is merged into main. Right now some unit tests are failing because of this issue.

1. Added unittests for all entropy features
2. Greatly improved perf for mean_change.
3. Improved Perf for time_reversal_asymmetry_statistic by reducing multiplications (but we need to do more additions). Multiplications are generally slower. This optimization only affects bigger time series.
4. Tuned absolute_energy in the eager case when time series is long, as NumPy's dot seems to outperform Polars's dot by a lot in that case.
5. Reverted the .cast() which was put there to avoid the issue mentioned above. Last checked the issue remains in 0.19.9.
6. Improved permutation entropy in the case tau = 1 by simplifying it a little bit. tau = 1 is the most common case and we get a 5-10% speed up on my machine.
7. Improved perf for index_mass_quantile by noting that x.abs().cumsum() is naturally sorted. This means using .searchsorted (O(log n)) instead of casting to boolean and then arg_max (O(n)) will be faster. Note arg_max on boolean has a shortcut which returns when the first true is found. This shortcut happens more often when q is small. However, casting to boolean still takes time. There are still more technical nuisance with regard to searchsorted . E.g. It doesn't do well when the search item is float but when series is int, etc.. But after some work those issues can be worked around and in the worst case performs on par with old implementation.
8. Improved perf for linear_trend by a constant factor by reducing redundant computation and some math tricks.
9. Improved perf for eager lempel_ziv_complexity with Rust. (reduced runtime by 60%+)
10. 5x faster autoregressive_coefficients. 