### PR TITLE
Feat linear trend test

### DIFF
--- a/functime/feature_extraction/tsfresh.py
+++ b/functime/feature_extraction/tsfresh.py
@@ -35,6 +35,7 @@ def absolute_energy(x: TIME_SERIES_T) -> FLOAT_INT_EXPR:
     """
     return x.dot(x)
 
+
 def absolute_maximum(x: TIME_SERIES_T) -> FLOAT_INT_EXPR:
     """
     Compute the absolute maximum of a time series.
@@ -199,7 +200,7 @@ def autocorrelation(x: TIME_SERIES_T, n_lags: int) -> FLOAT_EXPR:
         raise ValueError("Input `n_lags` must be >= 0")
     elif n_lags == 0:
         return 1.0
-    
+
     mean = x.mean()
     var = x.var(ddof=0)
     range_ = x.len() - n_lags
@@ -226,13 +227,17 @@ def autoregressive_coefficients(x: TIME_SERIES_T, n_lags: int) -> List[float]:
     """
     if isinstance(x, pl.Series):
         tail = len(x) - n_lags
-        data_x = x.to_frame().select(
-            *(
-                pl.col(x.name).shift(i).tail(tail).alias(str(i))
-                for i in range(1, n_lags + 1)
-            ),
-            pl.lit(1)
-        ).to_numpy()  # This matrix generation is faster than v-stack.
+        data_x = (
+            x.to_frame()
+            .select(
+                *(
+                    pl.col(x.name).shift(i).tail(tail).alias(str(i))
+                    for i in range(1, n_lags + 1)
+                ),
+                pl.lit(1),
+            )
+            .to_numpy()
+        )  # This matrix generation is faster than v-stack.
         y = x.tail(tail).to_numpy()
         # Ok to overwrite because data_x and y are copies
         return slq.lstsq(data_x, y, overwrite_a=True, overwrite_b=True, cond=None)[0]
@@ -260,7 +265,8 @@ def benford_correlation(x: TIME_SERIES_T) -> FLOAT_EXPR:
 
     if isinstance(x, pl.Series):
         counts = (
-            x.cast(pl.Utf8).str.strip_chars_start("-0.")
+            x.cast(pl.Utf8)
+            .str.strip_chars_start("-0.")
             .filter(x != 0)
             .str.slice(0, 1)
             .cast(pl.UInt8)
@@ -272,10 +278,16 @@ def benford_correlation(x: TIME_SERIES_T) -> FLOAT_EXPR:
         return np.corrcoef(counts - 1, _BENFORD_DIST_SERIES)[0, 1]
     else:
         y = x.cast(pl.Utf8).str.strip_chars_start("-0.")
-        counts = y.filter(x != 0).str.slice(0, 1).cast(pl.UInt8).append(
-            pl.int_range(1, 10, eager=False)
-        ).value_counts().sort().struct.field("counts")
-        return pl.corr(counts -1, pl.lit(_BENFORD_DIST_SERIES))
+        counts = (
+            y.filter(x != 0)
+            .str.slice(0, 1)
+            .cast(pl.UInt8)
+            .append(pl.int_range(1, 10, eager=False))
+            .value_counts()
+            .sort()
+            .struct.field("counts")
+        )
+        return pl.corr(counts - 1, pl.lit(_BENFORD_DIST_SERIES))
 
 
 def benford_correlation2(x: pl.Expr) -> pl.Expr:
@@ -360,10 +372,15 @@ def c3(x: TIME_SERIES_T, n_lags: int) -> FLOAT_EXPR:
         if twice_lag >= x.len():
             return np.nan
         else:
-            return (x * x.shift(n_lags) * x.shift(twice_lag)).sum() / (x.len() - twice_lag)
+            return (x * x.shift(n_lags) * x.shift(twice_lag)).sum() / (
+                x.len() - twice_lag
+            )
     else:
-    # Would potentially be faster if there is a pl.product_horizontal()
-        return ((x.mul(x.shift(n_lags)).mul(x.shift(twice_lag))).sum()).truediv((x.len() - twice_lag))
+        # Would potentially be faster if there is a pl.product_horizontal()
+        return ((x.mul(x.shift(n_lags)).mul(x.shift(twice_lag))).sum()).truediv(
+            x.len() - twice_lag
+        )
+
 
 def change_quantiles(
     x: TIME_SERIES_T, q_low: float, q_high: float, is_abs: bool
@@ -391,7 +408,9 @@ def change_quantiles(
     """
     if isinstance(x, pl.Series):
         frame = x.to_frame()
-        return frame.select(change_quantiles(pl.col(x.name), q_low, q_high, is_abs)).item(0,0)
+        return frame.select(
+            change_quantiles(pl.col(x.name), q_low, q_high, is_abs)
+        ).item(0, 0)
     else:
         if q_high <= q_low:
             return None
@@ -401,7 +420,7 @@ def change_quantiles(
             x.quantile(q_low, "linear"),
             x.quantile(q_high, "linear"),
         )
-        # I tested again, pl.all_horizontal is slightly faster than 
+        # I tested again, pl.all_horizontal is slightly faster than
         # pl.all_horizontal(y, y.shift_and_fill(False, periods=1))
         expr = x.diff().filter(pl.all_horizontal(y, y.shift_and_fill(False, periods=1)))
         if is_abs:
@@ -497,6 +516,7 @@ def count_below(x: TIME_SERIES_T, threshold: float = 0.0) -> FLOAT_EXPR:
     """
     return 100 * (x <= threshold).sum() / x.len()
 
+
 def count_below_mean(x: TIME_SERIES_T) -> INT_EXPR:
     """
     Count the number of values that are below the mean.
@@ -515,6 +535,7 @@ def count_below_mean(x: TIME_SERIES_T) -> INT_EXPR:
     else:
         y = x
     return (y < y.mean()).sum()
+
 
 def cwt_coefficients(
     x: pl.Series, widths: Sequence[int] = (2, 5, 10, 20), n_coefficients: int = 14
@@ -575,9 +596,7 @@ def energy_ratios(x: TIME_SERIES_T, n_chunks: int = 10) -> LIST_EXPR:
     else:
         r = x.count().mod(n_chunks)
         y = x.pow(2).append(
-            pl.repeat(0, n = pl.when(r == 0).then(0).otherwise(
-                pl.lit(n_chunks) - r
-            ))
+            pl.repeat(0, n=pl.when(r == 0).then(0).otherwise(pl.lit(n_chunks) - r))
         )
         seg_sum = y.reshape((n_chunks, -1)).list.sum()
         return (seg_sum / seg_sum.sum()).implode()
@@ -695,6 +714,7 @@ def has_duplicate(x: TIME_SERIES_T) -> BOOL_EXPR:
     """
     return x.is_duplicated().any()
 
+
 def has_duplicate_max(x: TIME_SERIES_T) -> BOOL_EXPR:
     """
     Check if the time-series contains any duplicate values equal to its maximum value.
@@ -710,6 +730,7 @@ def has_duplicate_max(x: TIME_SERIES_T) -> BOOL_EXPR:
     """
     return (x == x.max()).sum() > 1
 
+
 def has_duplicate_min(x: TIME_SERIES_T) -> BOOL_EXPR:
     """
     Check if the time-series contains duplicate values equal to its minimum value.
@@ -724,6 +745,7 @@ def has_duplicate_min(x: TIME_SERIES_T) -> BOOL_EXPR:
     bool | Expr
     """
     return (x == x.min()).sum() > 1
+
 
 def index_mass_quantile(x: TIME_SERIES_T, q: float) -> FLOAT_EXPR:
     """
@@ -748,7 +770,7 @@ def index_mass_quantile(x: TIME_SERIES_T, q: float) -> FLOAT_EXPR:
     y_abs = y.abs()
     y_sum = y.sum()
     n = x.len()
-    idx = (y_abs.cumsum() >= q*y_sum).arg_max()
+    idx = (y_abs.cumsum() >= q * y_sum).arg_max()
     return (idx + 1) / n
 
 
@@ -773,6 +795,7 @@ def large_standard_deviation(x: TIME_SERIES_T, ratio: float = 0.25) -> BOOL_EXPR
     x_interval = x.max() - x.min()
     return x_std > (ratio * x_interval)
 
+
 def last_location_of_maximum(x: TIME_SERIES_T) -> FLOAT_EXPR:
     """
     Returns the last location of the maximum value of x.
@@ -787,7 +810,7 @@ def last_location_of_maximum(x: TIME_SERIES_T) -> FLOAT_EXPR:
     -------
     float | Expr
     """
-    return 1.0 - x.reverse().arg_max()/x.len()
+    return 1.0 - x.reverse().arg_max() / x.len()
 
 
 def last_location_of_minimum(x: TIME_SERIES_T) -> FLOAT_EXPR:
@@ -804,13 +827,15 @@ def last_location_of_minimum(x: TIME_SERIES_T) -> FLOAT_EXPR:
     -------
     float | Expr
     """
-    return 1.0 - x.reverse().arg_min()/x.len()
+    return 1.0 - x.reverse().arg_min() / x.len()
 
 
-def lempel_ziv_complexity(x: TIME_SERIES_T, threshold: Union[float, pl.Expr]) -> FLOAT_EXPR:
+def lempel_ziv_complexity(
+    x: TIME_SERIES_T, threshold: Union[float, pl.Expr]
+) -> FLOAT_EXPR:
     """
     Calculate a complexity estimate based on the Lempel-Ziv compression algorithm. The
-    implementation here is currently taken from Lilian Besson. See the reference section 
+    implementation here is currently taken from Lilian Besson. See the reference section
     below. Instead of return the complexity value, we return a ratio w.r.t the length of
     the input series.
 
@@ -873,19 +898,20 @@ def linear_trend(x: TIME_SERIES_T) -> MAP_EXPR:
     Mapping[str, float] | Expr
     """
     if isinstance(x, pl.Series):
-        x_range = np.arange(start=1, stop=x.len() + 1)
-        beta = np.cov(x, x_range)[0, 1] / x.var()
+        x_range = np.arange(start=0, stop=x.len())
+        beta = np.cov(x_range, x)[0, 1] / np.var(x_range, ddof=1)
         alpha = x.mean() - beta * x_range.mean()
-        resid = x - beta * x_range + alpha
+        resid = x - (beta * x_range + alpha)
         return {"slope": beta, "intercept": alpha, "rss": np.dot(resid, resid)}
     else:
-        x_range = pl.int_range(1, x.len() + 1)
-        beta = pl.cov(x, x_range) / x.var()
+        x_range = pl.int_range(0, x.len())
+        beta = pl.cov(x_range, x) / x_range.var()
         alpha = x.mean() - beta * x_range.mean()
-        resid = x - beta * x_range + alpha
+        resid = x - (beta * x_range + alpha)
         return pl.struct(
             beta.alias("slope"), alpha.alias("intercept"), resid.dot(resid).alias("rss")
         )
+
 
 def longest_streak_above_mean(x: TIME_SERIES_T) -> INT_EXPR:
     """
@@ -893,7 +919,7 @@ def longest_streak_above_mean(x: TIME_SERIES_T) -> INT_EXPR:
     If all values in x are null, 0 will be returned. Note: this does not measure consecutive
     changes in time series, only counts the streak based on the original time series, not the
     differences.
-    
+
     Parameters
     ----------
     x : pl.Expr | pl.Series
@@ -909,7 +935,12 @@ def longest_streak_above_mean(x: TIME_SERIES_T) -> INT_EXPR:
         return 0 if result is None else result
     else:
         y = (x > x.mean()).rle()
-        return y.filter(y.struct.field("values")).struct.field("lengths").max().fill_null(0)
+        return (
+            y.filter(y.struct.field("values"))
+            .struct.field("lengths")
+            .max()
+            .fill_null(0)
+        )
 
 
 def longest_streak_below_mean(x: TIME_SERIES_T) -> INT_EXPR:
@@ -934,7 +965,13 @@ def longest_streak_below_mean(x: TIME_SERIES_T) -> INT_EXPR:
         return 0 if result is None else result
     else:
         y = (x < x.mean()).rle()
-        return y.filter(y.struct.field("values")).struct.field("lengths").max().fill_null(0)
+        return (
+            y.filter(y.struct.field("values"))
+            .struct.field("lengths")
+            .max()
+            .fill_null(0)
+        )
+
 
 def mean_abs_change(x: TIME_SERIES_T) -> FLOAT_EXPR:
     """
@@ -967,6 +1004,7 @@ def max_abs_change(x: TIME_SERIES_T) -> FLOAT_INT_EXPR:
     """
     return absolute_maximum(x.diff(null_behavior="drop"))
 
+
 def mean_change(x: TIME_SERIES_T) -> FLOAT_EXPR:
     """
     Compute mean change.
@@ -981,6 +1019,7 @@ def mean_change(x: TIME_SERIES_T) -> FLOAT_EXPR:
     float | Expr
     """
     return x.diff(null_behavior="drop").mean()
+
 
 def mean_n_absolute_max(x: TIME_SERIES_T, n_maxima: int) -> FLOAT_EXPR:
     """
@@ -1000,6 +1039,7 @@ def mean_n_absolute_max(x: TIME_SERIES_T, n_maxima: int) -> FLOAT_EXPR:
     if n_maxima <= 0:
         raise ValueError("The number of maxima should be > 0.")
     return x.abs().top_k(n_maxima).mean()
+
 
 def mean_second_derivative_central(x: TIME_SERIES_T) -> FLOAT_EXPR:
     """
@@ -1198,21 +1238,16 @@ def permutation_entropy(
         expr = permutation_entropy(pl.col(x.name), tau=tau, n_dims=n_dims)
         return frame.select(expr).item(0, 0)
     else:
-        return (
-            (  # create list columns
-                pl.concat_list(
-                    x.take_every(tau),
-                    *(x.shift(-i).take_every(tau) for i in range(1, n_dims))
-                )
-                .filter(x.shift(max_shift).take_every(tau).is_not_null())
-                .list.eval(
-                    pl.element().arg_sort()
-                )  # for each inner list, do an argsort
-                .value_counts()  # groupby and count, but returns a struct
-                .struct.field("counts")  # extract the field named "counts"
+        return (  # create list columns
+            pl.concat_list(
+                x.take_every(tau),
+                *(x.shift(-i).take_every(tau) for i in range(1, n_dims)),
             )
-            .entropy(normalize=True)
-        )
+            .filter(x.shift(max_shift).take_every(tau).is_not_null())
+            .list.eval(pl.element().arg_sort())  # for each inner list, do an argsort
+            .value_counts()  # groupby and count, but returns a struct
+            .struct.field("counts")  # extract the field named "counts"
+        ).entropy(normalize=True)
 
 
 def range_count(
@@ -1531,8 +1566,9 @@ def harmonic_mean(x: TIME_SERIES_T) -> FLOAT_EXPR:
     """
     return x.len() / (pl.lit(1.0) / x).sum()
 
-def range_over_mean(x:TIME_SERIES_T) -> FLOAT_EXPR:
-    '''
+
+def range_over_mean(x: TIME_SERIES_T) -> FLOAT_EXPR:
+    """
     Returns the range (max - min) over mean of the time series.
 
     Parameters
@@ -1543,12 +1579,13 @@ def range_over_mean(x:TIME_SERIES_T) -> FLOAT_EXPR:
     Returns
     -------
     float | Expr
-    '''
+    """
     return (x.max() - x.min()) / x.mean()
 
-def range_change(x:TIME_SERIES_T, percentage:bool = True) -> FLOAT_EXPR:
-    '''
-    Returns the maximum value range. If percentage is true, will compute 
+
+def range_change(x: TIME_SERIES_T, percentage: bool = True) -> FLOAT_EXPR:
+    """
+    Returns the maximum value range. If percentage is true, will compute
     (max - min) / min, which only makes sense when x is always positive.
 
     Parameters
@@ -1557,19 +1594,19 @@ def range_change(x:TIME_SERIES_T, percentage:bool = True) -> FLOAT_EXPR:
         Input time series.
     percentage : bool
         compute the percentage if set to True
-    
+
     Returns
     -------
     float | Expr
-    '''
+    """
     if percentage:
-        return x.max()/x.min() - 1.0
+        return x.max() / x.min() - 1.0
     else:
         return x.max() - x.min()
 
 
 def streak_length_stats(x: TIME_SERIES_T, above: bool, threshold: float) -> MAP_EXPR:
-    '''
+    """
     Returns some statistics of the length of the streaks of the time series. Note that the streaks here
     are about the changes for consecutive values in the time series, not the individual values.
 
@@ -1590,7 +1627,7 @@ def streak_length_stats(x: TIME_SERIES_T, above: bool, threshold: float) -> MAP_
     Returns
     -------
     float | Expr
-    '''
+    """
     if above:
         y = (x.diff().cast(pl.Float64) >= threshold).rle()
     else:
@@ -1606,7 +1643,7 @@ def streak_length_stats(x: TIME_SERIES_T, above: bool, threshold: float) -> MAP_
             "10-percentile": y.quantile(0.1),
             "median": y.median(),
             "90-percentile": y.quantile(0.9),
-            "mode": y.mode()[0]
+            "mode": y.mode()[0],
         }
     else:
         return pl.struct(
@@ -1617,11 +1654,12 @@ def streak_length_stats(x: TIME_SERIES_T, above: bool, threshold: float) -> MAP_
             y.quantile(0.1).alias("10-percentile"),
             y.median().alias("median"),
             y.quantile(0.9).alias("90-percentile"),
-            y.mode().first().alias("mode")
+            y.mode().first().alias("mode"),
         )
 
-def longest_streak_above(x:TIME_SERIES_T, threshold:float)-> TIME_SERIES_T:
-    '''
+
+def longest_streak_above(x: TIME_SERIES_T, threshold: float) -> TIME_SERIES_T:
+    """
     Returns the longest streak of changes >= threshold of the time series. A change
     is counted when (x_t+1 - x_t) >= threshold. Note that the streaks here
     are about the changes for consecutive values in the time series, not the individual values.
@@ -1636,17 +1674,23 @@ def longest_streak_above(x:TIME_SERIES_T, threshold:float)-> TIME_SERIES_T:
     Returns
     -------
     float | Expr
-    '''
+    """
     if isinstance(x, pl.Series):
         y = (x.diff().cast(pl.Float64) >= threshold).rle()
         streak_max = y.filter(y.struct.field("values")).struct.field("lengths").max()
         return 0 if streak_max is None else streak_max
     else:
         y = (x.diff() >= threshold).rle()
-        return y.filter(y.struct.field("values")).struct.field("lengths").max().fill_null(0)
+        return (
+            y.filter(y.struct.field("values"))
+            .struct.field("lengths")
+            .max()
+            .fill_null(0)
+        )
 
-def longest_streak_below(x:TIME_SERIES_T, threshold:float)-> TIME_SERIES_T:
-    '''
+
+def longest_streak_below(x: TIME_SERIES_T, threshold: float) -> TIME_SERIES_T:
+    """
     Returns the longest streak of changes <= threshold of the time series. A change
     is counted when (x_t+1 - x_t) <= threshold. Note that the streaks here
     are about the changes for consecutive values in the time series, not the individual values.
@@ -1661,20 +1705,26 @@ def longest_streak_below(x:TIME_SERIES_T, threshold:float)-> TIME_SERIES_T:
     Returns
     -------
     float | Expr
-    '''
+    """
     if isinstance(x, pl.Series):
         y = (x.diff().cast(pl.Float64) <= threshold).rle()
         streak_max = y.filter(y.struct.field("values")).struct.field("lengths").max()
         return 0 if streak_max is None else streak_max
     else:
         y = (x.diff() <= threshold).rle()
-        return y.filter(y.struct.field("values")).struct.field("lengths").max().fill_null(0)
+        return (
+            y.filter(y.struct.field("values"))
+            .struct.field("lengths")
+            .max()
+            .fill_null(0)
+        )
 
-def longest_winning_streak(x:TIME_SERIES_T) -> TIME_SERIES_T:
-    '''
+
+def longest_winning_streak(x: TIME_SERIES_T) -> TIME_SERIES_T:
+    """
     Returns the longest winning streak of the time series. A win is counted when
     (x_t+1 - x_t) >= 0
-    
+
     Parameters
     ----------
     x : pl.Expr | pl.Series
@@ -1683,12 +1733,12 @@ def longest_winning_streak(x:TIME_SERIES_T) -> TIME_SERIES_T:
     Returns
     -------
     float | Expr
-    '''
+    """
     return longest_streak_above(x, threshold=0)
 
 
-def longest_losing_streak(x:TIME_SERIES_T)-> TIME_SERIES_T:
-    '''
+def longest_losing_streak(x: TIME_SERIES_T) -> TIME_SERIES_T:
+    """
     Returns the longest losing streak of the time series. A loss is counted when
     (x_t+1 - x_t) <= 0
 
@@ -1700,8 +1750,9 @@ def longest_losing_streak(x:TIME_SERIES_T)-> TIME_SERIES_T:
     Returns
     -------
     float | Expr
-    '''
+    """
     return longest_streak_below(x, threshold=0)
+
 
 # FFT Features
 

--- a/tests/test_tsfresh.py
+++ b/tests/test_tsfresh.py
@@ -222,16 +222,6 @@ def test_count_range(S, res):
 
 
 @pytest.mark.parametrize(
-    "S, res",
-    [
-        ([-5, 0, 1], [26]),
-        ([0], [0]),
-        ([-1, 2, -3], [14]),
-        ([-1, 1.3], [2.6900000000000004]),
-        ([1], [1]),
-    ],
-)
-@pytest.mark.parametrize(
     "S, res, k",
     [
         # monotonic zero

--- a/tests/test_tsfresh.py
+++ b/tests/test_tsfresh.py
@@ -2,7 +2,6 @@ import numpy as np
 import polars as pl
 import pytest
 from polars.testing import assert_frame_equal, assert_series_equal
-import inspect
 
 # percent_recoccuring_values,
 from functime.feature_extraction.tsfresh import (
@@ -11,9 +10,15 @@ from functime.feature_extraction.tsfresh import (
     absolute_sum_of_changes,
     approximate_entropy,
     autocorrelation,
-    autoregressive_coefficients,
-    binned_entropy,
     benford_correlation,
+    binned_entropy,
+    c3,
+    change_quantiles,
+    cid_ce,
+    count_above,
+    count_above_mean,
+    count_below,
+    count_below_mean,
     first_location_of_maximum,
     first_location_of_minimum,
     has_duplicate,
@@ -22,1082 +27,944 @@ from functime.feature_extraction.tsfresh import (
     index_mass_quantile,
     last_location_of_maximum,
     last_location_of_minimum,
-    c3,
-    change_quantiles,
-    cid_ce,
-    count_above,
-    count_above_mean,
-    count_below,
-    count_below_mean,
+    lempel_ziv_complexity,
+    linear_trend,
+    longest_streak_above,
     longest_streak_above_mean,
+    longest_streak_below,
     longest_streak_below_mean,
+    max_abs_change,
     mean_n_absolute_max,
     mean_second_derivative_central,
-    percent_reocurring_points,
-    sum_reocurring_points,
-    sum_reocurring_values,
     number_peaks,
-    symmetry_looking,
-    time_reversal_asymmetry_statistic,
-    approximate_entropy,
     percent_reoccuring_values,
-    lempel_ziv_complexity,
-    range_over_mean,
+    percent_reocurring_points,
     range_change,
-    longest_winning_streak,
-    longest_streak_above,
-    longest_losing_streak,
-    longest_streak_below,
-    max_abs_change,
+    range_over_mean,
     ratio_beyond_r_sigma,
     ratio_n_unique_to_length,
-    root_mean_square
+    root_mean_square,
+    sum_reocurring_points,
+    sum_reocurring_values,
+    symmetry_looking,
+    time_reversal_asymmetry_statistic,
 )
 
 np.random.seed(42)
 
-@pytest.mark.parametrize("S, res", [
-    ([-5, 0, 1], [26]),
-    ([0], [0]),
-    ([-1, 2, -3], [14]),
-    ([-1, 1.3], [2.6900000000000004]),
-    ([1], [1])
-])
-def test_abolute_energy(S, res):
-    assert_frame_equal(
-        pl.DataFrame(
-            {"a": S}
-        ).select(
-            absolute_energy(pl.col("a"))
+
+@pytest.mark.parametrize(
+    "S, res, k",
+    [
+        # monotonic zero
+        ([0, 0, 0, 0, 0], [0, 0, 0], {}),
+        # monotonic non-zero +ve
+        ([1, 1, 1, 1, 1], [0, 1, 0], {}),
+        # monotonic non-zero negative
+        ([-1, -1, -1, -1, -1], [0, -1, 0], {}),
+        # +ve trend no intercept no residual
+        ([1, 2, 3, 4, 5], [1, 1, 0], {}),
+        # larger +ve trend with intercept with float vals
+        (list(np.linspace(2, 102, num=51)), [2, 2, 0], {}),
+        # +ve trend float slope
+        (list(np.linspace(0, 49, 99)), [0.5, 0, 0], {"check_exact": False}),
+        # noise centered around 0 with v low variance
+        (
+            list(temp := np.random.normal(0, 0.001, 100)) - np.mean(temp),
+            [0, 0, 0],
+            {"check_exact": False, "atol": 0.0001},
         ),
-        pl.DataFrame(pl.Series("a", res))
+        # -ve trend -1 intercept no residual
+        ([-1, -2, -3, -4, -5], [-1, -1, 0], {}),
+    ],
+)
+def test_linear_trend(S, res, k):
+    expected_df = (
+        pl.DataFrame(
+            {
+                "slope": res[0],
+                "intercept": res[1],
+                "rss": res[2],
+            },
+            schema={
+                "slope": pl.Float64,
+                "intercept": pl.Float64,
+                "rss": pl.Float64,
+            },
+        ).select(pl.struct(pl.all()).alias("slope"))
+    ).unnest("slope")
+    assert_frame_equal(
+        pl.DataFrame({"a": S}).select(linear_trend(pl.col("a"))).unnest("slope"),
+        expected_df,
+        **k,
     )
     assert_frame_equal(
-        pl.LazyFrame(
-            {"a": S}
-        ).select(
-            absolute_energy(pl.col("a"))
-        ).collect(),
-        pl.DataFrame(pl.Series("a", res))
+        pl.LazyFrame({"a": S})
+        .select(linear_trend(pl.col("a")))
+        .collect()
+        .unnest("slope"),
+        expected_df,
+        **k,
+    )
+    assert_frame_equal(
+        pl.DataFrame(linear_trend(pl.Series(S))),
+        expected_df,
+        **k,
+    )
+
+
+@pytest.mark.parametrize(
+    "S, res",
+    [
+        ([-5, 0, 1], [26]),
+        ([0], [0]),
+        ([-1, 2, -3], [14]),
+        ([-1, 1.3], [2.6900000000000004]),
+        ([1], [1]),
+    ],
+)
+def test_abolute_energy(S, res):
+    assert_frame_equal(
+        pl.DataFrame({"a": S}).select(absolute_energy(pl.col("a"))),
+        pl.DataFrame(pl.Series("a", res)),
+    )
+    assert_frame_equal(
+        pl.LazyFrame({"a": S}).select(absolute_energy(pl.col("a"))).collect(),
+        pl.DataFrame(pl.Series("a", res)),
     )
     assert absolute_energy(pl.Series(S)) == res[0]
 
 
-@pytest.mark.parametrize("S, res", [
-    ([-5, 0, 1], [5]),
-    ([0], [0]),
-    ([-1.0, 2.0, -3.0], [3.0]),
-])
+@pytest.mark.parametrize(
+    "S, res",
+    [
+        ([-5, 0, 1], [5]),
+        ([0], [0]),
+        ([-1.0, 2.0, -3.0], [3.0]),
+    ],
+)
 def test_absolute_maximum(S, res):
     assert_frame_equal(
-        pl.DataFrame(
-            {"a": S}
-        ).select(
-            absolute_maximum(pl.col("a"))
-        ),
-        pl.DataFrame(pl.Series("max", res))
+        pl.DataFrame({"a": S}).select(absolute_maximum(pl.col("a"))),
+        pl.DataFrame(pl.Series("max", res)),
     )
     assert_frame_equal(
-        pl.LazyFrame(
-            {"a": S}
-        ).select(
-            absolute_maximum(pl.col("a"))
-        ).collect(),
-        pl.DataFrame(pl.Series("max", res))
+        pl.LazyFrame({"a": S}).select(absolute_maximum(pl.col("a"))).collect(),
+        pl.DataFrame(pl.Series("max", res)),
     )
     assert absolute_maximum(pl.Series(S)) == res[0]
 
 
-@pytest.mark.parametrize("S, res", [
-    ([1, 1, 1, 1, 2, 1], [2]),
-    ([1.4, -1.3, 1.7, -1.2], [8.6]),
-    ([1], [0])
-])
+@pytest.mark.parametrize(
+    "S, res", [([1, 1, 1, 1, 2, 1], [2]), ([1.4, -1.3, 1.7, -1.2], [8.6]), ([1], [0])]
+)
 def test_absolute_sum_of_changes(S, res):
     assert_frame_equal(
-        pl.DataFrame(
-            {"a": S}
-        ).select(
-            absolute_sum_of_changes(pl.col("a"))
-        ),
-        pl.DataFrame(pl.Series("a", res))
+        pl.DataFrame({"a": S}).select(absolute_sum_of_changes(pl.col("a"))),
+        pl.DataFrame(pl.Series("a", res)),
     )
     assert_frame_equal(
-        pl.LazyFrame(
-            {"a": S}
-        ).select(
-            absolute_sum_of_changes(pl.col("a"))
-        ).collect(),
-        pl.DataFrame(pl.Series("a", res))
+        pl.LazyFrame({"a": S}).select(absolute_sum_of_changes(pl.col("a"))).collect(),
+        pl.DataFrame(pl.Series("a", res)),
     )
     assert absolute_sum_of_changes(pl.Series(S)) == res[0]
 
 
-@pytest.mark.parametrize("S, res, m, r, scale", [
-    ([1], 0, 2, 0.5, False),
-    ([12, 13, 15, 16, 17] * 10, 0.282456191276673, 2, 0.9, True),
-    ([1.4, -1.3, 1.7, -1.2], 0.0566330122651324, 2, 0.5, False),
-    ([0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1], 0.002223871246127107, 2, 0.5, False),
-    ([0, 1, 0, 0, 1, 0, 1, 0, 0, 1, 1, 1, 1, 0, 0, 1], 0.47133806162842484, 2, 0.5, False),
-    ([85, 80, 89] * 17, 1.099654110658932e-05, 2, 3, False),
-    ([85, 80, 89] * 17, 0.0, 2, 3, True)
-])
+@pytest.mark.parametrize(
+    "S, res, m, r, scale",
+    [
+        ([1], 0, 2, 0.5, False),
+        ([12, 13, 15, 16, 17] * 10, 0.282456191276673, 2, 0.9, True),
+        ([1.4, -1.3, 1.7, -1.2], 0.0566330122651324, 2, 0.5, False),
+        (
+            [0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1],
+            0.002223871246127107,
+            2,
+            0.5,
+            False,
+        ),
+        (
+            [0, 1, 0, 0, 1, 0, 1, 0, 0, 1, 1, 1, 1, 0, 0, 1],
+            0.47133806162842484,
+            2,
+            0.5,
+            False,
+        ),
+        ([85, 80, 89] * 17, 1.099654110658932e-05, 2, 3, False),
+        ([85, 80, 89] * 17, 0.0, 2, 3, True),
+    ],
+)
 def test_approximate_entropy(S, res, m, r, scale):
-    assert approximate_entropy(x = pl.Series(S), run_length=m, filtering_level=r, scale_by_std=scale) == res
+    assert (
+        approximate_entropy(
+            x=pl.Series(S), run_length=m, filtering_level=r, scale_by_std=scale
+        )
+        == res
+    )
 
-@pytest.mark.parametrize("S, res, n_lags", [
-    ([1, 2, 1, 2, 1, 2], [-1.0], 1),
-    ([1, 2, 1, 2, 1, 2], [1.0], 2),
-    ([1, 2, 1, 2, 1, 2], [1.0], 4),
-    ([0, 1, 2, 0, 1, 2], [-0.75], 2)
-])
+
+@pytest.mark.parametrize(
+    "S, res, n_lags",
+    [
+        ([1, 2, 1, 2, 1, 2], [-1.0], 1),
+        ([1, 2, 1, 2, 1, 2], [1.0], 2),
+        ([1, 2, 1, 2, 1, 2], [1.0], 4),
+        ([0, 1, 2, 0, 1, 2], [-0.75], 2),
+    ],
+)
 def test_autocorrelation(S, res, n_lags):
     assert_frame_equal(
-        pl.DataFrame(
-            {"a": S}
-        ).select(
-            autocorrelation(pl.col("a"), n_lags=n_lags)
-        ),
-        pl.DataFrame(pl.Series("a", res))
+        pl.DataFrame({"a": S}).select(autocorrelation(pl.col("a"), n_lags=n_lags)),
+        pl.DataFrame(pl.Series("a", res)),
     )
     assert_frame_equal(
-        pl.LazyFrame(
-            {"a": S}
-        ).select(
-            autocorrelation(pl.col("a"), n_lags=n_lags)
-        ).collect(),
-        pl.DataFrame(pl.Series("a", res))
+        pl.LazyFrame({"a": S})
+        .select(autocorrelation(pl.col("a"), n_lags=n_lags))
+        .collect(),
+        pl.DataFrame(pl.Series("a", res)),
     )
     assert autocorrelation(pl.Series(S), n_lags=n_lags) == res[0]
 
-@pytest.mark.parametrize("S, res, n_lags", [
-    ([1, 2, 1, 2, 1, 2], [1.0], 0)
-])
+
+@pytest.mark.parametrize("S, res, n_lags", [([1, 2, 1, 2, 1, 2], [1.0], 0)])
 def test_autocorrelation_shortcut(S, res, n_lags):
     assert_frame_equal(
-        pl.DataFrame(
-            {"a": S}
-        ).select(
-            autocorrelation(pl.col("a"), n_lags=n_lags)
-        ),
-        pl.DataFrame(pl.Series("literal", res))
+        pl.DataFrame({"a": S}).select(autocorrelation(pl.col("a"), n_lags=n_lags)),
+        pl.DataFrame(pl.Series("literal", res)),
     )
     assert_frame_equal(
-        pl.LazyFrame(
-            {"a": S}
-        ).select(
-            autocorrelation(pl.col("a"), n_lags=n_lags)
-        ).collect(),
-        pl.DataFrame(pl.Series("literal", res))
+        pl.LazyFrame({"a": S})
+        .select(autocorrelation(pl.col("a"), n_lags=n_lags))
+        .collect(),
+        pl.DataFrame(pl.Series("literal", res)),
     )
     assert autocorrelation(pl.Series(S), n_lags=n_lags) == res[0]
 
 
-
-@pytest.mark.parametrize("S, res, bin_count", [
-    ([10] * 100, [-0.0], 10),
-    ([10] * 10 + [1], [0.30463609734923813], 10),
-    (list(range(10)), [2.302585092994046], 100)
-])
+@pytest.mark.parametrize(
+    "S, res, bin_count",
+    [
+        ([10] * 100, [-0.0], 10),
+        ([10] * 10 + [1], [0.30463609734923813], 10),
+        (list(range(10)), [2.302585092994046], 100),
+    ],
+)
 def test_binned_entropy(S, res, bin_count):
     # Doesn't work for lazy mode
     assert_frame_equal(
-        pl.DataFrame(
-            {"a": S}
-        ).select(
-            binned_entropy(pl.col("a"), bin_count=bin_count)
-        ),
-        pl.DataFrame(pl.Series("counts", res))
+        pl.DataFrame({"a": S}).select(binned_entropy(pl.col("a"), bin_count=bin_count)),
+        pl.DataFrame(pl.Series("counts", res)),
     )
     assert_frame_equal(
-        pl.LazyFrame(
-            {"a": S}
-        ).select(
-            binned_entropy(pl.col("a"), bin_count=bin_count)
-        ).collect(),
-        pl.DataFrame(pl.Series("counts", res))
+        pl.LazyFrame({"a": S})
+        .select(binned_entropy(pl.col("a"), bin_count=bin_count))
+        .collect(),
+        pl.DataFrame(pl.Series("counts", res)),
     )
     assert binned_entropy(pl.Series(S), bin_count=bin_count) == res[0]
 
-@pytest.mark.parametrize("S, res, n_lags", [
-    ([1, 2, -3, 4], [-15.0], 1),
-    ([1]*10, [1.0], 1),
-    ([1]*10, [1.0], 2),
-    ([1]*10, [1.0], 3)
-])
+
+@pytest.mark.parametrize(
+    "S, res, n_lags",
+    [
+        ([1, 2, -3, 4], [-15.0], 1),
+        ([1] * 10, [1.0], 1),
+        ([1] * 10, [1.0], 2),
+        ([1] * 10, [1.0], 3),
+    ],
+)
 def test_c3(S, res, n_lags):
     assert_frame_equal(
-        pl.DataFrame(
-            {"a": S}
-        ).select(
-            c3(pl.col("a"), n_lags=n_lags)
-        ),
-        pl.DataFrame(pl.Series("a", res))
+        pl.DataFrame({"a": S}).select(c3(pl.col("a"), n_lags=n_lags)),
+        pl.DataFrame(pl.Series("a", res)),
     )
     assert_frame_equal(
-        pl.LazyFrame(
-            {"a": S}
-        ).select(
-            c3(pl.col("a"), n_lags=n_lags)
-        ).collect(),
-        pl.DataFrame(pl.Series("a", res))
+        pl.LazyFrame({"a": S}).select(c3(pl.col("a"), n_lags=n_lags)).collect(),
+        pl.DataFrame(pl.Series("a", res)),
     )
     assert c3(pl.Series(S), n_lags=n_lags) == res[0]
 
-@pytest.mark.parametrize("S, res, n_lags", [
-    ([1, 2, -3, 4], [np.nan], 2),
-    ([1, 2, -3, 4], [0.0], 3)
-])
+
+@pytest.mark.parametrize(
+    "S, res, n_lags", [([1, 2, -3, 4], [np.nan], 2), ([1, 2, -3, 4], [0.0], 3)]
+)
 def test_c3_not_define(S, res, n_lags):
     assert_frame_equal(
-        pl.DataFrame(
-            {"a": S}
-        ).select(
-            c3(pl.col("a"), n_lags=n_lags)
-        ),
-        pl.DataFrame(pl.Series("a", res))
+        pl.DataFrame({"a": S}).select(c3(pl.col("a"), n_lags=n_lags)),
+        pl.DataFrame(pl.Series("a", res)),
     )
     assert_frame_equal(
-        pl.LazyFrame(
-            {"a": S}
-        ).select(
-            c3(pl.col("a"), n_lags=n_lags)
-        ).collect(),
-        pl.DataFrame(pl.Series("a", res))
+        pl.LazyFrame({"a": S}).select(c3(pl.col("a"), n_lags=n_lags)).collect(),
+        pl.DataFrame(pl.Series("a", res)),
     )
     assert np.isnan(c3(pl.Series(S), n_lags=n_lags))
 
-@pytest.mark.parametrize("S, res, q_low, q_high, is_abs", [
-    ([0, 1, -9, 0, 0, 1, 0], [[1, 0, 1, 1]], 0.1, 0.9, True),
-    ([0, 1, -9, 0, 0, 1, 0], [[1, 0, 1, -1]], 0.1, 0.9, False),
-    (list(range(10)), [[1, 1, 1]], 0.25, 0.75, True)
-])
+
+@pytest.mark.parametrize(
+    "S, res, q_low, q_high, is_abs",
+    [
+        ([0, 1, -9, 0, 0, 1, 0], [[1, 0, 1, 1]], 0.1, 0.9, True),
+        ([0, 1, -9, 0, 0, 1, 0], [[1, 0, 1, -1]], 0.1, 0.9, False),
+        (list(range(10)), [[1, 1, 1]], 0.25, 0.75, True),
+    ],
+)
 def test_change_quantiles(S, res, q_low, q_high, is_abs):
     assert_frame_equal(
-        pl.DataFrame(
-            {"a": S}
-        ).select(
+        pl.DataFrame({"a": S}).select(
             change_quantiles(pl.col("a"), q_low=q_low, q_high=q_high, is_abs=is_abs)
         ),
-        pl.DataFrame(pl.Series("a", res))
+        pl.DataFrame(pl.Series("a", res)),
     )
     assert_frame_equal(
-        pl.LazyFrame(
-            {"a": S}
-        ).select(
+        pl.LazyFrame({"a": S})
+        .select(
             change_quantiles(pl.col("a"), q_low=q_low, q_high=q_high, is_abs=is_abs)
-        ).collect(),
-        pl.DataFrame(pl.Series("a", res))
+        )
+        .collect(),
+        pl.DataFrame(pl.Series("a", res)),
     )
     assert_series_equal(
         change_quantiles(pl.Series(S), q_low=q_low, q_high=q_high, is_abs=is_abs),
-        pl.Series(res[0])
+        pl.Series(res[0]),
     )
 
-@pytest.mark.parametrize("S, res, normalize", [
-    ([1, 1, 1], [0.0], False),
-    ([0, 4], [2.0], True),
-    ([100, 104], [2.0], True),
-    ([-4.33, -1.33, 2.67], [5.0], False)
-])
+
+@pytest.mark.parametrize(
+    "S, res, normalize",
+    [
+        ([1, 1, 1], [0.0], False),
+        ([0, 4], [2.0], True),
+        ([100, 104], [2.0], True),
+        ([-4.33, -1.33, 2.67], [5.0], False),
+    ],
+)
 def test_cid_ce(S, res, normalize):
     assert_frame_equal(
-        pl.DataFrame(
-            {"a": S}
-        ).select(
-            cid_ce(pl.col("a"), normalize=normalize)
-        ),
-        pl.DataFrame(pl.Series("a", res))
+        pl.DataFrame({"a": S}).select(cid_ce(pl.col("a"), normalize=normalize)),
+        pl.DataFrame(pl.Series("a", res)),
     )
     assert_frame_equal(
-        pl.LazyFrame(
-            {"a": S}
-        ).select(
-            cid_ce(pl.col("a"), normalize=normalize)
-        ).collect(),
-        pl.DataFrame(pl.Series("a", res))
+        pl.LazyFrame({"a": S})
+        .select(cid_ce(pl.col("a"), normalize=normalize))
+        .collect(),
+        pl.DataFrame(pl.Series("a", res)),
     )
     assert cid_ce(pl.Series(S), normalize=normalize) == res[0]
 
 
-@pytest.mark.parametrize("S, res, normalize", [
-    ([1, 1, 1], [np.nan], True)
-])
+@pytest.mark.parametrize("S, res, normalize", [([1, 1, 1], [np.nan], True)])
 def test_cid_ce_nan_case(S, res, normalize):
     assert_frame_equal(
-        pl.DataFrame(
-            {"a": S}
-        ).select(
-            cid_ce(pl.col("a"), normalize=normalize)
-        ),
-        pl.DataFrame(pl.Series("a", res))
+        pl.DataFrame({"a": S}).select(cid_ce(pl.col("a"), normalize=normalize)),
+        pl.DataFrame(pl.Series("a", res)),
     )
     assert_frame_equal(
-        pl.LazyFrame(
-            {"a": S}
-        ).select(
-            cid_ce(pl.col("a"), normalize=normalize)
-        ).collect(),
-        pl.DataFrame(pl.Series("a", res))
+        pl.LazyFrame({"a": S})
+        .select(cid_ce(pl.col("a"), normalize=normalize))
+        .collect(),
+        pl.DataFrame(pl.Series("a", res)),
     )
     np.isnan(cid_ce(pl.Series(S), normalize=normalize) == res[0])
 
-@pytest.mark.parametrize("S, res, threshold", [
-    ([0.1, 0.2, 0.3] * 3, [200 / 3], 0.2),
-    ([1] * 10, [100.0], 1.0),
-    (list(range(10)), [100.0], 0),
-    (list(range(10)), [50.0], 5)
-])
+
+@pytest.mark.parametrize(
+    "S, res, threshold",
+    [
+        ([0.1, 0.2, 0.3] * 3, [200 / 3], 0.2),
+        ([1] * 10, [100.0], 1.0),
+        (list(range(10)), [100.0], 0),
+        (list(range(10)), [50.0], 5),
+    ],
+)
 def test_count_above(S, res, threshold):
     assert_frame_equal(
-        pl.DataFrame(
-            {"a": S}
-        ).select(
-            count_above(pl.col("a"), threshold=threshold)
-        ),
-        pl.DataFrame(pl.Series("literal", res))
+        pl.DataFrame({"a": S}).select(count_above(pl.col("a"), threshold=threshold)),
+        pl.DataFrame(pl.Series("literal", res)),
     )
     assert_frame_equal(
-        pl.LazyFrame(
-            {"a": S}
-        ).select(
-            count_above(pl.col("a"), threshold=threshold)
-        ).collect(),
-        pl.DataFrame(pl.Series("literal", res))
+        pl.LazyFrame({"a": S})
+        .select(count_above(pl.col("a"), threshold=threshold))
+        .collect(),
+        pl.DataFrame(pl.Series("literal", res)),
     )
     assert count_above(pl.Series(S), threshold=threshold) == res[0]
 
-@pytest.mark.parametrize("S, res, threshold", [
-    ([0.1, 0.2, 0.3] * 3, [200 / 3], 0.2),
-    ([1] * 10, [100.0], 1),
-    (list(range(10)), [60.0], 5),
-    (list(range(10)), [10.0], 0)
-])
+
+@pytest.mark.parametrize(
+    "S, res, threshold",
+    [
+        ([0.1, 0.2, 0.3] * 3, [200 / 3], 0.2),
+        ([1] * 10, [100.0], 1),
+        (list(range(10)), [60.0], 5),
+        (list(range(10)), [10.0], 0),
+    ],
+)
 def test_count_below(S, res, threshold):
     assert_frame_equal(
-        pl.DataFrame(
-            {"a": S}
-        ).select(
-            count_below(pl.col("a"), threshold=threshold)
-        ),
-        pl.DataFrame(pl.Series("literal", res))
+        pl.DataFrame({"a": S}).select(count_below(pl.col("a"), threshold=threshold)),
+        pl.DataFrame(pl.Series("literal", res)),
     )
     assert_frame_equal(
-        pl.LazyFrame(
-            {"a": S}
-        ).select(
-            count_below(pl.col("a"), threshold=threshold)
-        ).collect(),
-        pl.DataFrame(pl.Series("literal", res))
+        pl.LazyFrame({"a": S})
+        .select(count_below(pl.col("a"), threshold=threshold))
+        .collect(),
+        pl.DataFrame(pl.Series("literal", res)),
     )
     assert count_below(pl.Series(S), threshold=threshold) == res[0]
 
 
-@pytest.mark.parametrize("S, res", [
-    ([1, 2, 1, 2, 1, 2], [3]),
-    ([1, 1, 1, 1, 1, 2], [1]),
-    ([1, 1, 1, 1, 1], [0])
-])
+@pytest.mark.parametrize(
+    "S, res",
+    [([1, 2, 1, 2, 1, 2], [3]), ([1, 1, 1, 1, 1, 2], [1]), ([1, 1, 1, 1, 1], [0])],
+)
 def test_count_above_mean(S, res):
     assert_frame_equal(
-        pl.DataFrame(
-            {"a": S}
-        ).select(
-            count_above_mean(pl.col("a"))
-        ),
-        pl.DataFrame(pl.Series("a", res, dtype=pl.UInt32))
+        pl.DataFrame({"a": S}).select(count_above_mean(pl.col("a"))),
+        pl.DataFrame(pl.Series("a", res, dtype=pl.UInt32)),
     )
     assert_frame_equal(
-        pl.LazyFrame(
-            {"a": S}
-        ).select(
-            count_above_mean(pl.col("a"))
-        ).collect(),
-        pl.DataFrame(pl.Series("a", res, dtype=pl.UInt32))
+        pl.LazyFrame({"a": S}).select(count_above_mean(pl.col("a"))).collect(),
+        pl.DataFrame(pl.Series("a", res, dtype=pl.UInt32)),
     )
     assert count_above_mean(pl.Series(S, dtype=pl.UInt32)) == res[0]
 
-@pytest.mark.parametrize("S, res", [
-    ([1, 2, 1, 2, 1, 2], [3]),
-    ([1, 1, 1, 1, 1, 2], [5]),
-    ([1, 1, 1, 1, 1], [0])
-])
+
+@pytest.mark.parametrize(
+    "S, res",
+    [([1, 2, 1, 2, 1, 2], [3]), ([1, 1, 1, 1, 1, 2], [5]), ([1, 1, 1, 1, 1], [0])],
+)
 def test_count_below_mean(S, res):
     assert_frame_equal(
-        pl.DataFrame(
-            {"a": S}
-        ).select(
-            count_below_mean(pl.col("a"))
-        ),
-        pl.DataFrame(pl.Series("a", res, dtype=pl.UInt32))
+        pl.DataFrame({"a": S}).select(count_below_mean(pl.col("a"))),
+        pl.DataFrame(pl.Series("a", res, dtype=pl.UInt32)),
     )
     assert_frame_equal(
-        pl.LazyFrame(
-            {"a": S}
-        ).select(
-            count_below_mean(pl.col("a"))
-        ).collect(),
-        pl.DataFrame(pl.Series("a", res, dtype=pl.UInt32))
+        pl.LazyFrame({"a": S}).select(count_below_mean(pl.col("a"))).collect(),
+        pl.DataFrame(pl.Series("a", res, dtype=pl.UInt32)),
     )
     assert count_below_mean(pl.Series(S, dtype=pl.UInt32)) == res[0]
 
-@pytest.mark.parametrize("S, res", [
-    ([1, 2, 1, 2, 1], [0.2]),
-    ([1.5, 2.6, 1.8, 2.1, 1.0], [0.2]),
-    ([2, 1, 1, 1, 1], [0.0]),
-    ([1, 1, 1, 1, 1], [0.0])
-])
+
+@pytest.mark.parametrize(
+    "S, res",
+    [
+        ([1, 2, 1, 2, 1], [0.2]),
+        ([1.5, 2.6, 1.8, 2.1, 1.0], [0.2]),
+        ([2, 1, 1, 1, 1], [0.0]),
+        ([1, 1, 1, 1, 1], [0.0]),
+    ],
+)
 def test_first_location_of_maximum(S, res):
     assert_frame_equal(
-        pl.DataFrame(
-            {"a": S}
-        ).select(
-            first_location_of_maximum(pl.col("a"))
-        ),
-        pl.DataFrame(pl.Series("a", res))
+        pl.DataFrame({"a": S}).select(first_location_of_maximum(pl.col("a"))),
+        pl.DataFrame(pl.Series("a", res)),
     )
     assert_frame_equal(
-        pl.LazyFrame(
-            {"a": S}
-        ).select(
-            first_location_of_maximum(pl.col("a"))
-        ).collect(),
-        pl.DataFrame(pl.Series("a", res))
+        pl.LazyFrame({"a": S}).select(first_location_of_maximum(pl.col("a"))).collect(),
+        pl.DataFrame(pl.Series("a", res)),
     )
     assert first_location_of_maximum(pl.Series(S)) == res[0]
 
-@pytest.mark.parametrize("S, res", [
-    ([1, 2, 1, 2, 1], [0.0]),
-    ([2, 1, 1, 1, 2], [0.2]),
-    ([2.7, 1.05, 1.2, 1.068, 2.3], [0.2]),
-    ([1, 1, 1, 1, 1], [0.0])
-])
+
+@pytest.mark.parametrize(
+    "S, res",
+    [
+        ([1, 2, 1, 2, 1], [0.0]),
+        ([2, 1, 1, 1, 2], [0.2]),
+        ([2.7, 1.05, 1.2, 1.068, 2.3], [0.2]),
+        ([1, 1, 1, 1, 1], [0.0]),
+    ],
+)
 def test_first_location_of_minimum(S, res):
     assert_frame_equal(
-        pl.DataFrame(
-            {"a": S}
-        ).select(
-            first_location_of_minimum(pl.col("a"))
-        ),
-        pl.DataFrame(pl.Series("a", res))
+        pl.DataFrame({"a": S}).select(first_location_of_minimum(pl.col("a"))),
+        pl.DataFrame(pl.Series("a", res)),
     )
     assert_frame_equal(
-        pl.LazyFrame(
-            {"a": S}
-        ).select(
-            first_location_of_minimum(pl.col("a"))
-        ).collect(),
-        pl.DataFrame(pl.Series("a", res))
+        pl.LazyFrame({"a": S}).select(first_location_of_minimum(pl.col("a"))).collect(),
+        pl.DataFrame(pl.Series("a", res)),
     )
     assert first_location_of_minimum(pl.Series(S)) == res[0]
 
 
-@pytest.mark.parametrize("S, res", [
-    ([2.1, 0, 0, 2.1, 1.1], [True]),
-    ([2.1, 0, 4, 2, 1.1], [False])
-])
+@pytest.mark.parametrize(
+    "S, res", [([2.1, 0, 0, 2.1, 1.1], [True]), ([2.1, 0, 4, 2, 1.1], [False])]
+)
 def test_has_duplicate(S, res):
     assert_frame_equal(
-        pl.DataFrame(
-            {"a": S}
-        ).select(
-            has_duplicate(pl.col("a"))
-        ),
-        pl.DataFrame(pl.Series("a", res))
+        pl.DataFrame({"a": S}).select(has_duplicate(pl.col("a"))),
+        pl.DataFrame(pl.Series("a", res)),
     )
     assert_frame_equal(
-        pl.LazyFrame(
-            {"a": S}
-        ).select(
-            has_duplicate(pl.col("a"))
-        ).collect(),
-        pl.DataFrame(pl.Series("a", res))
+        pl.LazyFrame({"a": S}).select(has_duplicate(pl.col("a"))).collect(),
+        pl.DataFrame(pl.Series("a", res)),
     )
     assert has_duplicate(pl.Series(S)) == res[0]
 
 
-@pytest.mark.parametrize("S, res", [
-    ([-2.1, 0, 0, -2.1, 1.1], [True]),
-    ([2.1, 0, -1, 2, 1.1], [False]),
-    ([1, 1, 1, 1], [True]),
-    ([0], [False])
-])
+@pytest.mark.parametrize(
+    "S, res",
+    [
+        ([-2.1, 0, 0, -2.1, 1.1], [True]),
+        ([2.1, 0, -1, 2, 1.1], [False]),
+        ([1, 1, 1, 1], [True]),
+        ([0], [False]),
+    ],
+)
 def test_has_duplicate_min(S, res):
     assert_frame_equal(
-        pl.DataFrame(
-            {"a": S}
-        ).select(
-            has_duplicate_min(pl.col("a"))
-        ),
-        pl.DataFrame(pl.Series("a", res))
+        pl.DataFrame({"a": S}).select(has_duplicate_min(pl.col("a"))),
+        pl.DataFrame(pl.Series("a", res)),
     )
     assert_frame_equal(
-        pl.LazyFrame(
-            {"a": S}
-        ).select(
-            has_duplicate_min(pl.col("a"))
-        ).collect(),
-        pl.DataFrame(pl.Series("a", res))
+        pl.LazyFrame({"a": S}).select(has_duplicate_min(pl.col("a"))).collect(),
+        pl.DataFrame(pl.Series("a", res)),
     )
     assert has_duplicate_min(pl.Series(S)) == res[0]
 
-@pytest.mark.parametrize("S, res", [
-    ([2.1, 0, 0, 2.1, 1.1], [True]),
-    ([2.1, 0, 0, 2, 1.1], [False]),
-    ([1, 1, 1, 1], [True]),
-    ([0], [False])
-])
+
+@pytest.mark.parametrize(
+    "S, res",
+    [
+        ([2.1, 0, 0, 2.1, 1.1], [True]),
+        ([2.1, 0, 0, 2, 1.1], [False]),
+        ([1, 1, 1, 1], [True]),
+        ([0], [False]),
+    ],
+)
 def test_has_duplicate_max(S, res):
     assert_frame_equal(
-        pl.DataFrame(
-            {"a": S}
-        ).select(
-            has_duplicate_max(pl.col("a"))
-        ),
-        pl.DataFrame(pl.Series("a", res))
+        pl.DataFrame({"a": S}).select(has_duplicate_max(pl.col("a"))),
+        pl.DataFrame(pl.Series("a", res)),
     )
     assert_frame_equal(
-        pl.LazyFrame(
-            {"a": S}
-        ).select(
-            has_duplicate_max(pl.col("a"))
-        ).collect(),
-        pl.DataFrame(pl.Series("a", res))
+        pl.LazyFrame({"a": S}).select(has_duplicate_max(pl.col("a"))).collect(),
+        pl.DataFrame(pl.Series("a", res)),
     )
     assert has_duplicate_max(pl.Series(S)) == res[0]
 
 
-@pytest.mark.parametrize("S, res, q", [
-    ([1] * 101, [0.504950495049505], 0.5),
-    ([0, 1, 1, 0, 0, 1, 0, 0], [0.25], 0.3),
-    ([0, 1, 1, 0, 0, 1, 0, 0], [0.375], 0.6),
-    ([0, 1, 1, 0, 0, 1, 0, 0], [0.75], 0.9)
-])
+@pytest.mark.parametrize(
+    "S, res, q",
+    [
+        ([1] * 101, [0.504950495049505], 0.5),
+        ([0, 1, 1, 0, 0, 1, 0, 0], [0.25], 0.3),
+        ([0, 1, 1, 0, 0, 1, 0, 0], [0.375], 0.6),
+        ([0, 1, 1, 0, 0, 1, 0, 0], [0.75], 0.9),
+    ],
+)
 def test_index_mass_quantile(S, res, q):
     assert_frame_equal(
-        pl.DataFrame(
-            {"a": S}
-        ).select(
-            index_mass_quantile(pl.col("a"), q)
-        ),
-        pl.DataFrame(pl.Series("a", res))
+        pl.DataFrame({"a": S}).select(index_mass_quantile(pl.col("a"), q)),
+        pl.DataFrame(pl.Series("a", res)),
     )
     assert_frame_equal(
-        pl.LazyFrame(
-            {"a": S}
-        ).select(
-            index_mass_quantile(pl.col("a"), q)
-        ).collect(),
-        pl.DataFrame(pl.Series("a", res))
+        pl.LazyFrame({"a": S}).select(index_mass_quantile(pl.col("a"), q)).collect(),
+        pl.DataFrame(pl.Series("a", res)),
     )
     assert index_mass_quantile(pl.Series(S), q) == res[0]
 
-@pytest.mark.parametrize("S, res", [
-    ([1, 2, 1, 2, 1], [1.0]),
-    ([1, 2, 1, 2, 2], [0.6]),
-    ([2.7, 1.05, 1.2, 1.068, 2.3], [0.4]),
-    ([2, 1, 1, 1, 2], [0.8])
-])
+
+@pytest.mark.parametrize(
+    "S, res",
+    [
+        ([1, 2, 1, 2, 1], [1.0]),
+        ([1, 2, 1, 2, 2], [0.6]),
+        ([2.7, 1.05, 1.2, 1.068, 2.3], [0.4]),
+        ([2, 1, 1, 1, 2], [0.8]),
+    ],
+)
 def test_last_location_of_minimum(S, res):
     assert_frame_equal(
-        pl.DataFrame(
-            {"a": S}
-        ).select(
-            last_location_of_minimum(pl.col("a"))
-        ),
-        pl.DataFrame(pl.Series("literal", res))
+        pl.DataFrame({"a": S}).select(last_location_of_minimum(pl.col("a"))),
+        pl.DataFrame(pl.Series("literal", res)),
     )
     assert_frame_equal(
-        pl.LazyFrame(
-            {"a": S}
-        ).select(
-            last_location_of_minimum(pl.col("a"))
-        ).collect(),
-        pl.DataFrame(pl.Series("literal", res))
+        pl.LazyFrame({"a": S}).select(last_location_of_minimum(pl.col("a"))).collect(),
+        pl.DataFrame(pl.Series("literal", res)),
     )
     assert last_location_of_minimum(pl.Series(S)) == res[0]
 
 
-@pytest.mark.parametrize("S, res", [
-    ([1, 2, 1, 2, 1], [0.8]),
-    ([1, 2, 1, 1, 2], [1.0]),
-    ([2.7, 1.05, 1.2, 1.068, 2.3], [0.19999999999999996]),
-    ([2, 1, 1, 1, 1], [0.19999999999999996])
-])
+@pytest.mark.parametrize(
+    "S, res",
+    [
+        ([1, 2, 1, 2, 1], [0.8]),
+        ([1, 2, 1, 1, 2], [1.0]),
+        ([2.7, 1.05, 1.2, 1.068, 2.3], [0.19999999999999996]),
+        ([2, 1, 1, 1, 1], [0.19999999999999996]),
+    ],
+)
 def test_last_location_of_maximum(S, res):
     assert_frame_equal(
-        pl.DataFrame(
-            {"a": S}
-        ).select(
-            last_location_of_maximum(pl.col("a"))
-        ),
-        pl.DataFrame(pl.Series("literal", res))
+        pl.DataFrame({"a": S}).select(last_location_of_maximum(pl.col("a"))),
+        pl.DataFrame(pl.Series("literal", res)),
     )
     assert_frame_equal(
-        pl.LazyFrame(
-            {"a": S}
-        ).select(
-            last_location_of_maximum(pl.col("a"))
-        ).collect(),
-        pl.DataFrame(pl.Series("literal", res))
+        pl.LazyFrame({"a": S}).select(last_location_of_maximum(pl.col("a"))).collect(),
+        pl.DataFrame(pl.Series("literal", res)),
     )
     assert last_location_of_maximum(pl.Series(S)) == res[0]
 
+
 def test_benford_correlation():
     # Nan, division by 0
-    X_uniform = pl.DataFrame({
-        "a": [1, 2, 3, 4, 5, 6, 7, 8, 9]
-    })
-    X_uniform_lazy = pl.LazyFrame({
-        "a": [1, 2, 3, 4, 5, 6, 7, 8, 9]
-    })
+    X_uniform = pl.DataFrame({"a": [1, 2, 3, 4, 5, 6, 7, 8, 9]})
+    X_uniform_lazy = pl.LazyFrame({"a": [1, 2, 3, 4, 5, 6, 7, 8, 9]})
     # Random serie
-    X_random = pl.DataFrame({
-        "a": [26.24, 3.03, -2.92, 3.5, -0.07, 0.35, 0.10, 0.51, -0.43]
-    })
-    X_random_lazy = pl.LazyFrame({
-        "a": [26.24, 3.03, -2.92, 3.5, -0.07, 0.35, 0.10, 0.51, -0.43]
-    })
+    X_random = pl.DataFrame(
+        {"a": [26.24, 3.03, -2.92, 3.5, -0.07, 0.35, 0.10, 0.51, -0.43]}
+    )
+    X_random_lazy = pl.LazyFrame(
+        {"a": [26.24, 3.03, -2.92, 3.5, -0.07, 0.35, 0.10, 0.51, -0.43]}
+    )
     # Fibo, distribution same as benford law
     l_fibo = [0, 1]
     for i in range(2, 50):
         l_fibo.append(l_fibo[i - 1] + l_fibo[i - 2])
-    
-    X_fibo = pl.DataFrame({
-        "a": l_fibo
-    })
 
-    X_fibo_lazy = pl.LazyFrame({
-        "a": l_fibo
-    })
+    X_fibo = pl.DataFrame({"a": l_fibo})
+
+    X_fibo_lazy = pl.LazyFrame({"a": l_fibo})
     assert_frame_equal(
-        X_uniform.select(
-            benford_correlation(pl.col("a"))
-        ),
-        pl.DataFrame({"counts": [np.nan]})
+        X_uniform.select(benford_correlation(pl.col("a"))),
+        pl.DataFrame({"counts": [np.nan]}),
     )
     assert_frame_equal(
-        X_uniform_lazy.select(
-            benford_correlation(pl.col("a"))
-        ).collect(),
-        pl.DataFrame({"counts": [np.nan]})
+        X_uniform_lazy.select(benford_correlation(pl.col("a"))).collect(),
+        pl.DataFrame({"counts": [np.nan]}),
     )
     assert_frame_equal(
-        X_random.select(
-            benford_correlation(pl.col("a"))
-        ),
-        pl.DataFrame({"counts": [0.39753280229716703]})
+        X_random.select(benford_correlation(pl.col("a"))),
+        pl.DataFrame({"counts": [0.39753280229716703]}),
     )
     assert_frame_equal(
-        X_random_lazy.select(
-            benford_correlation(pl.col("a"))
-        ).collect(),
-        pl.DataFrame({"counts": [0.39753280229716703]})
+        X_random_lazy.select(benford_correlation(pl.col("a"))).collect(),
+        pl.DataFrame({"counts": [0.39753280229716703]}),
     )
     assert_frame_equal(
-        X_fibo.select(
-            benford_correlation(pl.col("a"))
-        ),
-        pl.DataFrame({"counts": [0.9959632739083689]})
+        X_fibo.select(benford_correlation(pl.col("a"))),
+        pl.DataFrame({"counts": [0.9959632739083689]}),
     )
     assert_frame_equal(
-        X_fibo_lazy.select(
-            benford_correlation(pl.col("a"))
-        ).collect(),
-        pl.DataFrame({"counts": [0.9959632739083689]})
+        X_fibo_lazy.select(benford_correlation(pl.col("a"))).collect(),
+        pl.DataFrame({"counts": [0.9959632739083689]}),
     )
 
-@pytest.mark.parametrize("S, res", [
-    ([1, 2, 1, 1, 1, 2, 2, 2], [3]),
-    ([1, 2, 3, 4, 5, 6], [3]),
-    ([1, 2, 3, 4, 5], [2]),
-    ([1, 2, 1], [1]),
-    ([1, 1, 1], [0]),
-    ([], [0])
-])
+
+@pytest.mark.parametrize(
+    "S, res",
+    [
+        ([1, 2, 1, 1, 1, 2, 2, 2], [3]),
+        ([1, 2, 3, 4, 5, 6], [3]),
+        ([1, 2, 3, 4, 5], [2]),
+        ([1, 2, 1], [1]),
+        ([1, 1, 1], [0]),
+        ([], [0]),
+    ],
+)
 def test_longest_streak_below_mean(S, res):
     assert_frame_equal(
-        pl.DataFrame(
-            {"a": S}
-        ).select(
+        pl.DataFrame({"a": S}).select(
             longest_streak_below_mean(pl.col("a")).alias("lengths")
         ),
-        pl.DataFrame(pl.Series("lengths", res, dtype=pl.UInt64))
+        pl.DataFrame(pl.Series("lengths", res, dtype=pl.UInt64)),
     )
     assert_frame_equal(
-        pl.LazyFrame(
-            {"a": S}
-        ).select(
-            longest_streak_below_mean(pl.col("a")).alias("lengths")
-        ).collect(),
-        pl.DataFrame(pl.Series("lengths", res, dtype=pl.UInt64))
+        pl.LazyFrame({"a": S})
+        .select(longest_streak_below_mean(pl.col("a")).alias("lengths"))
+        .collect(),
+        pl.DataFrame(pl.Series("lengths", res, dtype=pl.UInt64)),
     )
 
 
-@pytest.mark.parametrize("S, res", [
-    ([1, 2, 1, 2, 1, 2, 2, 1], [2]),
-    ([1, 2, 3, 4, 5, 6], [3]),
-    ([1, 2, 3, 4, 5], [2]),
-    ([1, 2, 1], [1]),
-    ([1, 1, 1], [0]),
-    ([], [0])
-])
+@pytest.mark.parametrize(
+    "S, res",
+    [
+        ([1, 2, 1, 2, 1, 2, 2, 1], [2]),
+        ([1, 2, 3, 4, 5, 6], [3]),
+        ([1, 2, 3, 4, 5], [2]),
+        ([1, 2, 1], [1]),
+        ([1, 1, 1], [0]),
+        ([], [0]),
+    ],
+)
 def test_longest_streak_above_mean(S, res):
     assert_frame_equal(
-        pl.DataFrame(
-            {"a": S}
-        ).select(
+        pl.DataFrame({"a": S}).select(
             longest_streak_above_mean(pl.col("a")).alias("lengths")
         ),
-        pl.DataFrame(pl.Series("lengths", res, dtype=pl.UInt64))
+        pl.DataFrame(pl.Series("lengths", res, dtype=pl.UInt64)),
     )
     assert_frame_equal(
-        pl.LazyFrame(
-            {"a": S}
-        ).select(
-            longest_streak_above_mean(pl.col("a")).alias("lengths")
-        ).collect(),
-        pl.DataFrame(pl.Series("lengths", res, dtype=pl.UInt64))
+        pl.LazyFrame({"a": S})
+        .select(longest_streak_above_mean(pl.col("a")).alias("lengths"))
+        .collect(),
+        pl.DataFrame(pl.Series("lengths", res, dtype=pl.UInt64)),
     )
 
 
-@pytest.mark.parametrize("S, res, ratio", [
-    ([0, 1] * 10 + [10, 20, -30], [3.0/23.0], 1),
-    ([0, 1] * 10 + [10, 20, -30], [2.0/23.0], 2),
-    ([0, 1] * 10 + [10, 20, -30], [1.0/23.0], 3)
-])
+@pytest.mark.parametrize(
+    "S, res, ratio",
+    [
+        ([0, 1] * 10 + [10, 20, -30], [3.0 / 23.0], 1),
+        ([0, 1] * 10 + [10, 20, -30], [2.0 / 23.0], 2),
+        ([0, 1] * 10 + [10, 20, -30], [1.0 / 23.0], 3),
+    ],
+)
 def test_ratio_beyond_r_sigma(S, res, ratio):
     assert_frame_equal(
-        pl.DataFrame(
-            {"a": S}
-        ).select(
-            ratio_beyond_r_sigma(pl.col("a"), ratio = ratio)
-        ),
-        pl.DataFrame(pl.Series("a", res))
+        pl.DataFrame({"a": S}).select(ratio_beyond_r_sigma(pl.col("a"), ratio=ratio)),
+        pl.DataFrame(pl.Series("a", res)),
     )
     assert_frame_equal(
-        pl.LazyFrame(
-            {"a": S}
-        ).select(
-            ratio_beyond_r_sigma(pl.col("a"), ratio = ratio)
-        ).collect(),
-        pl.DataFrame(pl.Series("a", res))
+        pl.LazyFrame({"a": S})
+        .select(ratio_beyond_r_sigma(pl.col("a"), ratio=ratio))
+        .collect(),
+        pl.DataFrame(pl.Series("a", res)),
     )
-    assert ratio_beyond_r_sigma(pl.Series(S), ratio = ratio) == res[0]
+    assert ratio_beyond_r_sigma(pl.Series(S), ratio=ratio) == res[0]
 
 
-@pytest.mark.parametrize("S, res, ratio", [
-    ([], [np.nan], 1)
-])
+@pytest.mark.parametrize("S, res, ratio", [([], [np.nan], 1)])
 def test_ratio_beyond_r_sigma_nan_case(S, res, ratio):
     assert_frame_equal(
-        pl.DataFrame(
-            {"a": S}
-        ).select(
-            ratio_beyond_r_sigma(pl.col("a"), ratio = ratio)
-        ),
-        pl.DataFrame(pl.Series("a", res))
+        pl.DataFrame({"a": S}).select(ratio_beyond_r_sigma(pl.col("a"), ratio=ratio)),
+        pl.DataFrame(pl.Series("a", res)),
     )
     assert_frame_equal(
-        pl.LazyFrame(
-            {"a": S}
-        ).select(
-            ratio_beyond_r_sigma(pl.col("a"), ratio = ratio)
-        ).collect(),
-        pl.DataFrame(pl.Series("a", res))
+        pl.LazyFrame({"a": S})
+        .select(ratio_beyond_r_sigma(pl.col("a"), ratio=ratio))
+        .collect(),
+        pl.DataFrame(pl.Series("a", res)),
     )
     with pytest.raises(ZeroDivisionError):
-        ratio_beyond_r_sigma(pl.Series(S), ratio = ratio)
+        ratio_beyond_r_sigma(pl.Series(S), ratio=ratio)
 
 
-@pytest.mark.parametrize("S, res", [
-    ([1, 1, 2, 3, 4], [0.8]),
-    ([1, 1.5, 2, 3], [1.0]),
-    ([1], [1.0]),
-    ([1.111, -2.45, 1.111, 2.45], [0.75])
-])
+@pytest.mark.parametrize(
+    "S, res",
+    [
+        ([1, 1, 2, 3, 4], [0.8]),
+        ([1, 1.5, 2, 3], [1.0]),
+        ([1], [1.0]),
+        ([1.111, -2.45, 1.111, 2.45], [0.75]),
+    ],
+)
 def test_ratio_n_unique_to_length(S, res):
     assert_frame_equal(
-        pl.DataFrame(
-            {"a": S}
-        ).select(
-            ratio_n_unique_to_length(pl.col("a"))
-        ),
-        pl.DataFrame(pl.Series("a", res))
+        pl.DataFrame({"a": S}).select(ratio_n_unique_to_length(pl.col("a"))),
+        pl.DataFrame(pl.Series("a", res)),
     )
     assert_frame_equal(
-        pl.LazyFrame(
-            {"a": S}
-        ).select(
-            ratio_n_unique_to_length(pl.col("a"))
-        ).collect(),
-        pl.DataFrame(pl.Series("a", res))
+        pl.LazyFrame({"a": S}).select(ratio_n_unique_to_length(pl.col("a"))).collect(),
+        pl.DataFrame(pl.Series("a", res)),
     )
     assert ratio_n_unique_to_length(pl.Series(S)) == res[0]
 
 
-@pytest.mark.parametrize("S, res", [
-    ([], [np.nan])
-])
+@pytest.mark.parametrize("S, res", [([], [np.nan])])
 def test_ratio_n_unique_to_length_nan_case(S, res):
     assert_frame_equal(
-        pl.DataFrame(
-            {"a": S}
-        ).select(
-            ratio_n_unique_to_length(pl.col("a"))
-        ),
-        pl.DataFrame(pl.Series("a", res))
+        pl.DataFrame({"a": S}).select(ratio_n_unique_to_length(pl.col("a"))),
+        pl.DataFrame(pl.Series("a", res)),
     )
     assert_frame_equal(
-        pl.LazyFrame(
-            {"a": S}
-        ).select(
-            ratio_n_unique_to_length(pl.col("a"))
-        ).collect(),
-        pl.DataFrame(pl.Series("a", res))
+        pl.LazyFrame({"a": S}).select(ratio_n_unique_to_length(pl.col("a"))).collect(),
+        pl.DataFrame(pl.Series("a", res)),
     )
     with pytest.raises(ZeroDivisionError):
         ratio_n_unique_to_length(pl.Series(S))
 
 
-@pytest.mark.parametrize("S, res", [
-    ([1, 1, 1, 2, 2], [1.4832396974191326]),
-    ([1.0, 1.0, 1.0, 2.0, 2.0], [1.4832396974191326]),
-    ([0], [0.0]),
-    ([1], [1.0]),
-    ([-1], [1.0])
-])
+@pytest.mark.parametrize(
+    "S, res",
+    [
+        ([1, 1, 1, 2, 2], [1.4832396974191326]),
+        ([1.0, 1.0, 1.0, 2.0, 2.0], [1.4832396974191326]),
+        ([0], [0.0]),
+        ([1], [1.0]),
+        ([-1], [1.0]),
+    ],
+)
 def test_root_mean_square(S, res):
     assert_frame_equal(
-        pl.DataFrame(
-            {"a": S}
-        ).select(
-            root_mean_square(pl.col("a"))
-        ),
-        pl.DataFrame(pl.Series("a", res))
+        pl.DataFrame({"a": S}).select(root_mean_square(pl.col("a"))),
+        pl.DataFrame(pl.Series("a", res)),
     )
     assert_frame_equal(
-        pl.LazyFrame(
-            {"a": S}
-        ).select(
-            root_mean_square(pl.col("a"))
-        ).collect(),
-        pl.DataFrame(pl.Series("a", res))
+        pl.LazyFrame({"a": S}).select(root_mean_square(pl.col("a"))).collect(),
+        pl.DataFrame(pl.Series("a", res)),
     )
     assert root_mean_square(pl.Series(S)) == res[0]
 
 
-@pytest.mark.parametrize("S, res", [
-    ([], [np.nan])
-])
+@pytest.mark.parametrize("S, res", [([], [np.nan])])
 def test_root_mean_square_nan_case(S, res):
     assert_frame_equal(
-        pl.DataFrame(
-            {"a": S}
-        ).select(
-            root_mean_square(pl.col("a"))
-        ),
-        pl.DataFrame(pl.Series("a", res))
+        pl.DataFrame({"a": S}).select(root_mean_square(pl.col("a"))),
+        pl.DataFrame(pl.Series("a", res)),
     )
     assert_frame_equal(
-        pl.LazyFrame(
-            {"a": S}
-        ).select(
-            root_mean_square(pl.col("a"))
-        ).collect(),
-        pl.DataFrame(pl.Series("a", res))
+        pl.LazyFrame({"a": S}).select(root_mean_square(pl.col("a"))).collect(),
+        pl.DataFrame(pl.Series("a", res)),
     )
     np.isnan(root_mean_square(pl.Series(S)))
 
 
-
-@pytest.mark.parametrize("S, n_max, res", [
-    ([], 1, [None]),
-    ([12, 3], 10, [7.5]),
-    ([-1, -5, 4, 10], 3, [6.333333]),
-    ([0, -5, -9], 2, [7.0]),
-    ([0, 0, 0], 1, [0.0])
-])
+@pytest.mark.parametrize(
+    "S, n_max, res",
+    [
+        ([], 1, [None]),
+        ([12, 3], 10, [7.5]),
+        ([-1, -5, 4, 10], 3, [6.333333]),
+        ([0, -5, -9], 2, [7.0]),
+        ([0, 0, 0], 1, [0.0]),
+    ],
+)
 def test_mean_n_absolute_max(S, n_max, res):
     assert_frame_equal(
-        pl.DataFrame(
-            {"a": S}
-        ).select(
+        pl.DataFrame({"a": S}).select(
             mean_n_absolute_max(pl.col("a"), n_maxima=n_max).cast(pl.Float64)
         ),
-        pl.DataFrame(pl.Series("a", res, dtype=pl.Float64))
+        pl.DataFrame(pl.Series("a", res, dtype=pl.Float64)),
     )
     assert_frame_equal(
-        pl.LazyFrame(
-            {"a": S}
-        ).select(
-            mean_n_absolute_max(pl.col("a"), n_maxima=n_max).cast(pl.Float64)
-        ).collect(),
-        pl.DataFrame(pl.Series("a", res, dtype=pl.Float64))
+        pl.LazyFrame({"a": S})
+        .select(mean_n_absolute_max(pl.col("a"), n_maxima=n_max).cast(pl.Float64))
+        .collect(),
+        pl.DataFrame(pl.Series("a", res, dtype=pl.Float64)),
     )
+
 
 def test_mean_n_absolute_max_value_error():
     with pytest.raises(ValueError):
-        mean_n_absolute_max(
-            x = pl.Series([12, 3]),
-            n_maxima = 0
-        )
+        mean_n_absolute_max(x=pl.Series([12, 3]), n_maxima=0)
     with pytest.raises(ValueError):
-        mean_n_absolute_max(
-            x = pl.Series([12, 3]),
-            n_maxima = -1
-        )
+        mean_n_absolute_max(x=pl.Series([12, 3]), n_maxima=-1)
 
 
-@pytest.mark.parametrize("S, res", [
-    ([1, 1, 2, 3, 4], [0.4]),
-    ([1, 1.5, 2, 3], [0]),
-    ([1], [0]),
-    ([1.111, -2.45, 1.111, 2.45], [0.5]),
-    ([], [np.nan])
-])
+@pytest.mark.parametrize(
+    "S, res",
+    [
+        ([1, 1, 2, 3, 4], [0.4]),
+        ([1, 1.5, 2, 3], [0]),
+        ([1], [0]),
+        ([1.111, -2.45, 1.111, 2.45], [0.5]),
+        ([], [np.nan]),
+    ],
+)
 def test_percent_reoccuring_values(S, res):
     assert_frame_equal(
-        pl.DataFrame(
-            {"a": S}
-        ).select(
-            percent_reoccuring_values(pl.col("a"))
-        ),
-        pl.DataFrame(pl.Series("a", res, dtype=pl.Float64))
+        pl.DataFrame({"a": S}).select(percent_reoccuring_values(pl.col("a"))),
+        pl.DataFrame(pl.Series("a", res, dtype=pl.Float64)),
     )
     assert_frame_equal(
-        pl.LazyFrame(
-            {"a": S}
-        ).select(
-            percent_reoccuring_values(pl.col("a"))
-        ).collect(),
-        pl.DataFrame(pl.Series("a", res, dtype=pl.Float64))
+        pl.LazyFrame({"a": S}).select(percent_reoccuring_values(pl.col("a"))).collect(),
+        pl.DataFrame(pl.Series("a", res, dtype=pl.Float64)),
     )
 
 
-@pytest.mark.parametrize("S, res", [
-    ([1, 1, 2, 3, 4], [0.25]),
-    ([1, 1.5, 2, 3], [0]),
-    ([1], [0]),
-    ([1.111, -2.45, 1.111, 2.45], [1.0 / 3.0])
-])
-def test_percent_reoccuring_values(S, res):
+@pytest.mark.parametrize(
+    "S, res",
+    [
+        ([1, 1, 2, 3, 4], [0.25]),
+        ([1, 1.5, 2, 3], [0]),
+        ([1], [0]),
+        ([1.111, -2.45, 1.111, 2.45], [1.0 / 3.0]),
+    ],
+)
+def test_percent_reoccuring_values(S, res):  # noqa
     assert_frame_equal(
-        pl.DataFrame(
-            {"a": S}
-        ).select(
-            percent_reoccuring_values(pl.col("a"))
-        ),
-        pl.DataFrame(pl.Series("a", res, dtype=pl.Float64))
+        pl.DataFrame({"a": S}).select(percent_reoccuring_values(pl.col("a"))),
+        pl.DataFrame(pl.Series("a", res, dtype=pl.Float64)),
     )
     assert_frame_equal(
-        pl.LazyFrame(
-            {"a": S}
-        ).select(
-            percent_reoccuring_values(pl.col("a"))
-        ).collect(),
-        pl.DataFrame(pl.Series("a", res, dtype=pl.Float64))
+        pl.LazyFrame({"a": S}).select(percent_reoccuring_values(pl.col("a"))).collect(),
+        pl.DataFrame(pl.Series("a", res, dtype=pl.Float64)),
     )
 
 
-@pytest.mark.parametrize("S, res", [
-    ([1, 1, 2, 3, 4, 4], [10]),
-    ([1, 1.5, 2, 3], [0.0]),
-    ([1], [0]),
-    ([1.111, -2.45, 1.111, 2.45], [2.222])
-])
+@pytest.mark.parametrize(
+    "S, res",
+    [
+        ([1, 1, 2, 3, 4, 4], [10]),
+        ([1, 1.5, 2, 3], [0.0]),
+        ([1], [0]),
+        ([1.111, -2.45, 1.111, 2.45], [2.222]),
+    ],
+)
 def test_sum_reocurring_points(S, res):
     assert_frame_equal(
-        pl.DataFrame(
-            {"a": S}
-        ).select(
-            sum_reocurring_points(pl.col("a"))
-        ),
-        pl.DataFrame(pl.Series("a", res))
+        pl.DataFrame({"a": S}).select(sum_reocurring_points(pl.col("a"))),
+        pl.DataFrame(pl.Series("a", res)),
     )
     assert_frame_equal(
-        pl.LazyFrame(
-            {"a": S}
-        ).select(
-            sum_reocurring_points(pl.col("a"))
-        ).collect(),
-        pl.DataFrame(pl.Series("a", res))
+        pl.LazyFrame({"a": S}).select(sum_reocurring_points(pl.col("a"))).collect(),
+        pl.DataFrame(pl.Series("a", res)),
     )
 
 
-@pytest.mark.parametrize("S, res", [
-    ([1, 1, 2, 3, 4, 4], [5]),
-    ([1, 1.5, 2, 3], [0.0]),
-    ([1], [0]),
-    ([1.111, -2.45, 1.111, 2.45], [1.111])
-])
+@pytest.mark.parametrize(
+    "S, res",
+    [
+        ([1, 1, 2, 3, 4, 4], [5]),
+        ([1, 1.5, 2, 3], [0.0]),
+        ([1], [0]),
+        ([1.111, -2.45, 1.111, 2.45], [1.111]),
+    ],
+)
 def test_sum_reocurring_values(S, res):
     assert_frame_equal(
-        pl.DataFrame(
-            {"a": S}
-        ).select(
-            sum_reocurring_values(pl.col("a"))
-        ),
-        pl.DataFrame(pl.Series("a", res))
+        pl.DataFrame({"a": S}).select(sum_reocurring_values(pl.col("a"))),
+        pl.DataFrame(pl.Series("a", res)),
     )
     assert_frame_equal(
-        pl.LazyFrame(
-            {"a": S}
-        ).select(
-            sum_reocurring_values(pl.col("a"))
-        ).collect(),
-        pl.DataFrame(pl.Series("a", res))
+        pl.LazyFrame({"a": S}).select(sum_reocurring_values(pl.col("a"))).collect(),
+        pl.DataFrame(pl.Series("a", res)),
     )
 
 
-@pytest.mark.parametrize("S, res", [
-    ([1, 1, 2, 3, 4], [0.4]),
-    ([1, 1.5, 2, 3], [0]),
-    ([1], [0]),
-    ([1.111, -2.45, 1.111, 2.45], [0.5]),
-    ([], [np.nan])
-])
+@pytest.mark.parametrize(
+    "S, res",
+    [
+        ([1, 1, 2, 3, 4], [0.4]),
+        ([1, 1.5, 2, 3], [0]),
+        ([1], [0]),
+        ([1.111, -2.45, 1.111, 2.45], [0.5]),
+        ([], [np.nan]),
+    ],
+)
 def test_percent_reocurring_points(S, res):
     assert_frame_equal(
-        pl.DataFrame(
-            {"a": S}
-        ).select(
-            percent_reocurring_points(pl.col("a"))
-        ),
-        pl.DataFrame(pl.Series("a", res, dtype=pl.Float64))
+        pl.DataFrame({"a": S}).select(percent_reocurring_points(pl.col("a"))),
+        pl.DataFrame(pl.Series("a", res, dtype=pl.Float64)),
     )
     assert_frame_equal(
-        pl.LazyFrame(
-            {"a": S}
-        ).select(
-            percent_reocurring_points(pl.col("a"))
-        ).collect(),
-        pl.DataFrame(pl.Series("a", res, dtype=pl.Float64))
+        pl.LazyFrame({"a": S}).select(percent_reocurring_points(pl.col("a"))).collect(),
+        pl.DataFrame(pl.Series("a", res, dtype=pl.Float64)),
     )
 
 
-@pytest.mark.parametrize("S, n, res", [
-    ([0, 5, 2, 3, 0, 1, 2, 3, 4, 5, 4, 3, 2, 1], 1, [3]),
-    ([0, 1, 2, 3, 0, 1, 2, 3, 4, 5, 4, 3, 2, 1], 2, [2]),
-    ([0, 1, 2, 3, 0, 1, 2, 3, 4, 5, 4, 3, 2, 1], 3, [2]),
-    ([0, 1, 2, 3, 0, 1, 2, 3, 4, 5, 4, 3, 2, 1], 4, [1])
-])
+@pytest.mark.parametrize(
+    "S, n, res",
+    [
+        ([0, 5, 2, 3, 0, 1, 2, 3, 4, 5, 4, 3, 2, 1], 1, [3]),
+        ([0, 1, 2, 3, 0, 1, 2, 3, 4, 5, 4, 3, 2, 1], 2, [2]),
+        ([0, 1, 2, 3, 0, 1, 2, 3, 4, 5, 4, 3, 2, 1], 3, [2]),
+        ([0, 1, 2, 3, 0, 1, 2, 3, 4, 5, 4, 3, 2, 1], 4, [1]),
+    ],
+)
 def test_number_peaks(S, n, res):
     assert_frame_equal(
-        pl.DataFrame(
-            {"a": S}
-        ).select(
-            number_peaks(pl.col("a"), n).alias("a")
-        ),
-        pl.DataFrame(pl.Series("a", res, dtype=pl.UInt32))
+        pl.DataFrame({"a": S}).select(number_peaks(pl.col("a"), n).alias("a")),
+        pl.DataFrame(pl.Series("a", res, dtype=pl.UInt32)),
     )
     assert_frame_equal(
-        pl.LazyFrame(
-            {"a": S}
-        ).select(
-            number_peaks(pl.col("a"), n).alias("a")
-        ).collect(),
-        pl.DataFrame(pl.Series("a", res, dtype=pl.UInt32))
+        pl.LazyFrame({"a": S})
+        .select(number_peaks(pl.col("a"), n).alias("a"))
+        .collect(),
+        pl.DataFrame(pl.Series("a", res, dtype=pl.UInt32)),
     )
 
 
@@ -1190,29 +1057,16 @@ def test_augmented_dickey_fuller(x, param, res):
     ],
 )
 def test_mean_second_derivative_central(x, res):
-    assert_series_equal(
-        mean_second_derivative_central(x),
-        res
-    )
+    assert_series_equal(mean_second_derivative_central(x), res)
+
+
 # This test needs to be rewritten..
 @pytest.mark.parametrize(
     "x, r, res",
     [
-        (
-            pl.Series([-1, -1, 1, 1]),
-            0.05,
-            True
-        ),
-        (
-            pl.Series([-2, -1, 0, 1, 1]),
-            0.05,
-            False
-        ),
-        (
-            pl.Series([-2, -1, 0, 1, 1]),
-            0.1,
-            True
-        ),
+        (pl.Series([-1, -1, 1, 1]), 0.05, True),
+        (pl.Series([-2, -1, 0, 1, 1]), 0.05, False),
+        (pl.Series([-2, -1, 0, 1, 1]), 0.1, True),
     ],
 )
 def test_symmetry_looking(x, r, res):
@@ -1221,10 +1075,8 @@ def test_symmetry_looking(x, r, res):
 
     df = x.to_frame()
     assert_frame_equal(
-        df.select(
-            symmetry_looking(pl.col(x.name), ratio=r)
-        ),
-        pl.DataFrame({x.name:[res]})
+        df.select(symmetry_looking(pl.col(x.name), ratio=r)),
+        pl.DataFrame({x.name: [res]}),
     )
 
 
@@ -1236,124 +1088,134 @@ def test_time_reversal_asymmetry_statistic(x, lag, res):
 
 
 def test_lempel_ziv_complexity():
-    a = pl.Series([1,0,0,1,1,1,1,0,1,1,0,0,0,0,1,0])
-    assert lempel_ziv_complexity(a, threshold = 0) * len(a) == 8
-    a = pl.Series([1,0,0,1,1,1,1,0,1,1,0,0,0,0,1,0,0,0,0,0,1,0])
-    assert lempel_ziv_complexity(a, threshold = 0) * len(a) == 9
-    a = pl.Series([1,0,0,1,1,1,1,0,1,1,0,0,0,0,1,0,0,0,0,0,1,0,1,0])
-    assert lempel_ziv_complexity(a, threshold = 0) * len(a) == 10
+    a = pl.Series([1, 0, 0, 1, 1, 1, 1, 0, 1, 1, 0, 0, 0, 0, 1, 0])
+    assert lempel_ziv_complexity(a, threshold=0) * len(a) == 8
+    a = pl.Series([1, 0, 0, 1, 1, 1, 1, 0, 1, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 1, 0])
+    assert lempel_ziv_complexity(a, threshold=0) * len(a) == 9
+    a = pl.Series(
+        [1, 0, 0, 1, 1, 1, 1, 0, 1, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 1, 0, 1, 0]
+    )
+    assert lempel_ziv_complexity(a, threshold=0) * len(a) == 10
 
 
-@pytest.mark.parametrize("S, res", [
-    (list(range(100)), 99),
-    ([0, 0 , 0, 0, -1, 2, -3, 1], 3),
-    (list(range(100, 0, -1)), 0)
-])
+@pytest.mark.parametrize(
+    "S, res",
+    [
+        (list(range(100)), 99),
+        ([0, 0, 0, 0, -1, 2, -3, 1], 3),
+        (list(range(100, 0, -1)), 0),
+    ],
+)
 def test_longest_streak_above(S, res):
-
     x = pl.Series(S)
     assert longest_streak_above(x, threshold=0) == res
     df = x.to_frame()
     assert_frame_equal(
         df.select(
-            longest_streak_above(pl.col(x.name), threshold=0).alias(x.name).cast(pl.Int64)
+            longest_streak_above(pl.col(x.name), threshold=0)
+            .alias(x.name)
+            .cast(pl.Int64)
         ),
-        pl.DataFrame({x.name:[res]})
+        pl.DataFrame({x.name: [res]}),
     )
 
     assert_frame_equal(
-        df.lazy().select(
-            longest_streak_above(pl.col(x.name), threshold=0).alias(x.name).cast(pl.Int64)
-        ).collect(),
-        pl.DataFrame({x.name:[res]})
+        df.lazy()
+        .select(
+            longest_streak_above(pl.col(x.name), threshold=0)
+            .alias(x.name)
+            .cast(pl.Int64)
+        )
+        .collect(),
+        pl.DataFrame({x.name: [res]}),
     )
 
-@pytest.mark.parametrize("S, res", [
-    (list(range(100)), 0),
-    ([0, 0, 0, 0, -1, 2, -3, 1], 4),
-    (list(range(100, 0, -1)), 99)
-])
-def test_longest_streak_below(S, res):
 
+@pytest.mark.parametrize(
+    "S, res",
+    [
+        (list(range(100)), 0),
+        ([0, 0, 0, 0, -1, 2, -3, 1], 4),
+        (list(range(100, 0, -1)), 99),
+    ],
+)
+def test_longest_streak_below(S, res):
     x = pl.Series(S)
     assert longest_streak_below(x, threshold=0) == res
     df = x.to_frame()
     assert_frame_equal(
         df.select(
-            longest_streak_below(pl.col(x.name), threshold=0).alias(x.name).cast(pl.Int64)
+            longest_streak_below(pl.col(x.name), threshold=0)
+            .alias(x.name)
+            .cast(pl.Int64)
         ),
-        pl.DataFrame({x.name:[res]})
+        pl.DataFrame({x.name: [res]}),
     )
 
     assert_frame_equal(
-        df.lazy().select(
-            longest_streak_below(pl.col(x.name), threshold=0).alias(x.name).cast(pl.Int64)
-        ).collect(),
-        pl.DataFrame({x.name:[res]})
+        df.lazy()
+        .select(
+            longest_streak_below(pl.col(x.name), threshold=0)
+            .alias(x.name)
+            .cast(pl.Int64)
+        )
+        .collect(),
+        pl.DataFrame({x.name: [res]}),
     )
 
-@pytest.mark.parametrize("S, res", [
-    (list(range(100)), 1),
-    ([0, -100, 1,2,3,4,5,6,7,8,9], 101),
-    ([-50, -100, 200, 3, 9, 12], 300)
-])
-def test_max_abs_change(S, res):
 
+@pytest.mark.parametrize(
+    "S, res",
+    [
+        (list(range(100)), 1),
+        ([0, -100, 1, 2, 3, 4, 5, 6, 7, 8, 9], 101),
+        ([-50, -100, 200, 3, 9, 12], 300),
+    ],
+)
+def test_max_abs_change(S, res):
     x = pl.Series(S)
     assert max_abs_change(x) == res
     df = x.to_frame()
     assert_frame_equal(
-        df.select(
-            max_abs_change(pl.col(x.name)).alias(x.name)
-        ),
-        pl.DataFrame({x.name:[res]})
+        df.select(max_abs_change(pl.col(x.name)).alias(x.name)),
+        pl.DataFrame({x.name: [res]}),
     )
     assert_frame_equal(
-        df.lazy().select(
-            max_abs_change(pl.col(x.name)).alias(x.name)
-        ).collect(),
-        pl.DataFrame({x.name:[res]})
+        df.lazy().select(max_abs_change(pl.col(x.name)).alias(x.name)).collect(),
+        pl.DataFrame({x.name: [res]}),
     )
 
-@pytest.mark.parametrize("S, res", [
-    ([1, 1, 1, 1, 1], 0.),
-    ([1, 2, 3, 4, 5, 6, 7], 1.5),
-    ([1], 0.),
-    ([0.1, 0.2, 0.8, 0.9], 1.6)
-])
-def test_range_over_mean_and_range(S, res):
 
+@pytest.mark.parametrize(
+    "S, res",
+    [
+        ([1, 1, 1, 1, 1], 0.0),
+        ([1, 2, 3, 4, 5, 6, 7], 1.5),
+        ([1], 0.0),
+        ([0.1, 0.2, 0.8, 0.9], 1.6),
+    ],
+)
+def test_range_over_mean_and_range(S, res):
     # The tests here are non-exhaustive, but is good enough
     x = pl.Series(S)
     assert range_over_mean(x) == res
-    range_ = (np.max(S) - np.min(S))
+    range_ = np.max(S) - np.min(S)
     range_chg_pct = range_ / np.min(S)
     assert range_change(x, percentage=False) == range_
     assert range_change(x, percentage=True) == range_chg_pct
     df = x.to_frame()
     assert_frame_equal(
-        df.select(
-            range_change(pl.col(x.name), percentage=False)
-        ),
-        pl.DataFrame({x.name:[range_]})
+        df.select(range_change(pl.col(x.name), percentage=False)),
+        pl.DataFrame({x.name: [range_]}),
     )
     assert_frame_equal(
-        df.select(
-            range_over_mean(pl.col(x.name))
-        ),
-        pl.DataFrame({x.name:[res]})
+        df.select(range_over_mean(pl.col(x.name))), pl.DataFrame({x.name: [res]})
     )
     assert_frame_equal(
-        df.lazy().select(
-            range_change(pl.col(x.name), percentage=True)
-        ).collect(),
-        pl.DataFrame({x.name:[range_chg_pct]})
+        df.lazy().select(range_change(pl.col(x.name), percentage=True)).collect(),
+        pl.DataFrame({x.name: [range_chg_pct]}),
     )
     assert_frame_equal(
-        df.lazy().select(
-            range_over_mean(pl.col(x.name))
-        ).collect(),
-        pl.DataFrame({x.name:[res]})
+        df.lazy().select(range_over_mean(pl.col(x.name))).collect(),
+        pl.DataFrame({x.name: [res]}),
     )
-
-


### PR DESCRIPTION
**Add linear trend test and fix linear Trend**

linear_trend had some issues. these were:
- linear_trend was using the wrong variance to calculate the slope.
- numpy ddof was missing for variance in the series case.
- In calculating the residuals, the function was missing a brackets.
- Even if everything worked, the output would be a little different from tsfresh behaviour, which assumes that n starts at 0. This is potentially intentional. Reviewer can make judgement as to which is better; n starting at zero is unconventional.

Added linear trend tests. The values are based on n starting at zero. 
Of note: for floating points, there appears to be some imprecision currently which means that I am not forcing an **exact** check in the test (see the 0.5 slope test) - may wish to investigate and fix instead.

Since I made some not insignificant changes to the function, I may have gone overboard on the tests here. 
I wanted to make sure what I was doing was about right!