### PR TITLE
perf: More tse optimisations

### DIFF
--- a/functime/feature_extraction/tsfresh.py
+++ b/functime/feature_extraction/tsfresh.py
@@ -1146,7 +1146,7 @@ def partial_autocorrelation(x: TIME_SERIES_T, n_lags: int) -> float:
     return NotImplemented
 
 
-def percent_reocurring_points(x: TIME_SERIES_T) -> float:
+def percent_reoccurring_points(x: TIME_SERIES_T) -> float:
     """
     Returns the percentage of non-unique data points in the time series. Non-unique data points are those that occur
     more than once in the time series.
@@ -1170,7 +1170,8 @@ def percent_reocurring_points(x: TIME_SERIES_T) -> float:
     return 1 - x.is_unique().sum() / x.len()
 
 
-def percent_reoccuring_values(x: TIME_SERIES_T) -> FLOAT_EXPR:
+
+def percent_reoccurring_values(x: TIME_SERIES_T) -> FLOAT_EXPR:
     """
     Returns the percentage of values that are present in the time series more than once.
 
@@ -1480,7 +1481,7 @@ def spkt_welch_density(x: TIME_SERIES_T, n_coeffs: Optional[int] = None) -> LIST
 
 
 # Originally named: `sum_of_reoccurring_data_points`
-def sum_reocurring_points(x: TIME_SERIES_T) -> FLOAT_INT_EXPR:
+def sum_reoccurring_points(x: TIME_SERIES_T) -> FLOAT_INT_EXPR:
     """
     Returns the sum of all data points that are present in the time series more than once.
 
@@ -1502,7 +1503,7 @@ def sum_reocurring_points(x: TIME_SERIES_T) -> FLOAT_INT_EXPR:
 
 
 # Originally named: `sum_of_reoccurring_values`
-def sum_reocurring_values(x: TIME_SERIES_T) -> FLOAT_INT_EXPR:
+def sum_reoccurring_values(x: TIME_SERIES_T) -> FLOAT_INT_EXPR:
     """
     Returns the sum of all values that are present in the time series more than once.
 
@@ -1528,10 +1529,11 @@ def sum_reocurring_values(x: TIME_SERIES_T) -> FLOAT_INT_EXPR:
             pl.col(x.name).sum()
         ).item(0, 0)
     else:
-        vc = x.alias("_").value_counts()
+        name = x.meta.output_name() or "_"
+        vc = x.value_counts()
         return vc.filter(
             vc.struct.field("counts") > 1
-        ).struct.field("_").sum()
+        ).struct.field(name).sum()
 
 
 def symmetry_looking(x: TIME_SERIES_T, ratio: float = 0.25) -> BOOL_EXPR:

--- a/functime/feature_extraction/tsfresh.py
+++ b/functime/feature_extraction/tsfresh.py
@@ -285,27 +285,25 @@ def benford_correlation(x: TIME_SERIES_T) -> FLOAT_EXPR:
 
     if isinstance(x, pl.Series):
         counts = (
-            x.cast(pl.Utf8)
-            .str.strip_chars_start("-0.")
-            .filter(x != 0)
-            .str.slice(0, 1)
-            .cast(pl.UInt8)
-            .append(pl.int_range(1, 10, eager=True, dtype=pl.UInt8))
-            .value_counts()
-            .sort(by=x.name)
-            .get_column("counts")
+            pl.int_range(1, 10, eager=True, dtype=pl.UInt8)
+            .cast(pl.Utf8)
+            .append(
+                x.cast(pl.Utf8)
+                .str.strip_chars_start("-0.")
+                .filter(x != 0)
+                .str.slice(0, 1)
+            ).unique_counts()
         )
         return np.corrcoef(counts - 1, _BENFORD_DIST_SERIES)[0, 1]
     else:
-        y = x.cast(pl.Utf8).str.strip_chars_start("-0.")
         counts = (
-            y.filter(x != 0)
-            .str.slice(0, 1)
-            .cast(pl.UInt8)
-            .append(pl.int_range(1, 10, eager=False))
-            .value_counts()
-            .sort()
-            .struct.field("counts")
+            pl.int_range(1, 10, eager=False)
+            .cast(pl.Utf8)
+            .append(
+                x.cast(pl.Utf8).str.strip_chars_start("-0.")
+                .filter(x != 0)
+                .str.slice(0, 1)
+            ).unique_counts()
         )
         return pl.corr(counts - 1, pl.lit(_BENFORD_DIST_SERIES))
 
@@ -323,7 +321,7 @@ def benford_correlation2(x: pl.Expr) -> pl.Expr:
 
     Returns
     -------
-    An expression for benford_correlation representing a float
+    float | Expr
     """
     counts = (
         # This part can be simplified once the log10(1000) precision issue is resolved.
@@ -396,7 +394,6 @@ def c3(x: TIME_SERIES_T, n_lags: int) -> FLOAT_EXPR:
                 x.len() - twice_lag
             )
     else:
-        # Would potentially be faster if there is a pl.product_horizontal()
         return ((x.mul(x.shift(n_lags)).mul(x.shift(twice_lag))).sum()).truediv(
             x.len() - twice_lag
         )
@@ -426,15 +423,15 @@ def change_quantiles(
     -------
     list of float | Expr
     """
+    if q_high <= q_low:
+        return None
+
     if isinstance(x, pl.Series):
         frame = x.to_frame()
         return frame.select(
             change_quantiles(pl.col(x.name), q_low, q_high, is_abs)
         ).item(0, 0)
     else:
-        if q_high <= q_low:
-            return None
-
         # Use linear to conform to NumPy
         y = x.is_between(
             x.quantile(q_low, "linear"),
@@ -599,16 +596,16 @@ def energy_ratios(x: TIME_SERIES_T, n_chunks: int = 10) -> LIST_EXPR:
     # We calculate all 1,2,3,...,n_chunk at once
     if isinstance(x, pl.Series):
         r = x.len() % n_chunks
-        if r != 0:
-            y = x.pow(2).extend_constant(0, n_chunks - r)
-        else:
+        if r == 0:
             y = x.pow(2)
+        else:
+            y = x.pow(2).extend_constant(0, n_chunks - r)
         seg_sum = y.reshape((n_chunks, -1)).list.sum()
         return (seg_sum / seg_sum.sum()).to_list()
     else:
         r = x.count().mod(n_chunks)
         y = x.pow(2).append(
-            pl.repeat(0, n=pl.when(r == 0).then(0).otherwise(pl.lit(n_chunks) - r))
+            pl.repeat(0, n = r.eq(0).not_() * (pl.lit(n_chunks) - r))
         )
         seg_sum = y.reshape((n_chunks, -1)).list.sum()
         return (seg_sum / seg_sum.sum()).implode()
@@ -678,7 +675,7 @@ def fourier_entropy(x: TIME_SERIES_T, n_bins: int = 10) -> float:
 
 def friedrich_coefficients(
     x: TIME_SERIES_T, polynomial_order: int = 3, n_quantiles: int = 30
-) -> List[float]:
+) -> LIST_EXPR:
     """
     Calculate the Friedrich coefficients of a time series.
 
@@ -695,26 +692,32 @@ def friedrich_coefficients(
     -------
     list of float
     """
-    X = (
-        x.alias("signal")
-        .to_frame()
-        .with_columns(
-            delta=x.diff().alias("delta"),
-            quantile=x.qcut(q=n_quantiles, labels=[str(i) for i in range(n_quantiles)]),
+    if isinstance(x, pl.Series):
+        x_means = (
+            x.alias("signal")
+            .to_frame()
+            .lazy()
+            .with_columns(
+                pl.col("signal").diff().alias("delta"),
+                pl.col("signal").qcut(
+                    q=n_quantiles, labels=[str(i) for i in range(n_quantiles)]
+                ).alias("quantile")
+            ).group_by("quantile").agg(
+                pl.all().mean()
+            ).drop_nulls()
+            .collect()
         )
-        .lazy()
-    )
-    X_means = (
-        X.groupby("quantile")
-        .agg([pl.all().mean()])
-        .drop_nulls()
-        .collect(streaming=True)
-    )
-    return np.polyfit(
-        X_means.get_column("signal").to_numpy(zero_copy_only=True),
-        X_means.get_column("delta").to_numpy(zero_copy_only=True),
-        deg=polynomial_order,
-    )
+        # This is a Vandermonde matrix. May have shortcuts in our use case, as again length >> degree.
+        # Not sure if NumPy is taking advantage of this though.
+        return np.polyfit(
+            x_means.get_column("signal").to_numpy(zero_copy_only=True),
+            x_means.get_column("delta").to_numpy(zero_copy_only=True),
+            deg=polynomial_order,
+        )
+    else:
+        logger.info("Expression version of friedrich_coefficients is not yet implemented due to "
+                    "technical difficulty regarding Polars Expression Plugins.")
+        return NotImplemented
 
 
 def has_duplicate(x: TIME_SERIES_T) -> BOOL_EXPR:
@@ -919,8 +922,8 @@ def linear_trend(x: TIME_SERIES_T) -> MAP_EXPR:
         if n == 1:
             return {"slope": np.nan, "intercept":np.nan, "rss": np.nan}
 
-        m = n-1
-        x_range_mean = m/2
+        m = n - 1
+        x_range_mean = m / 2
         x_range = np.arange(start=0, stop=n)
         x_mean = x.mean()
         beta = np.dot(x - x_mean, x_range - x_range_mean) / (m * np.var(x_range, ddof=1))
@@ -930,7 +933,7 @@ def linear_trend(x: TIME_SERIES_T) -> MAP_EXPR:
     else:
         m = x.len() - 1
         x_range = pl.int_range(0, x.len())
-        x_range_mean = m/2
+        x_range_mean = m / 2
         beta = (x - x.mean()).dot(x_range - x_range_mean) / (m * x_range.var())
         alpha = x.mean() - beta * x_range_mean
         resid = x - (beta * x_range + alpha)
@@ -1105,9 +1108,8 @@ def number_crossings(x: TIME_SERIES_T, crossing_value: float = 0.0) -> FLOAT_EXP
     -------
     float | Expr
     """
-    return (
-        ((x > crossing_value).cast(pl.Int8).diff(null_behavior="drop").abs() == 1).sum()
-    )
+    y = x > crossing_value
+    return y.eq(y.shift(1)).not_().sum()
 
 
 def number_cwt_peaks(x: pl.Series, max_width: int = 5) -> float:
@@ -1165,8 +1167,7 @@ def percent_reocurring_points(x: TIME_SERIES_T) -> float:
     -------
     float
     """
-    count = x.unique_counts()
-    return count.filter(count > 1).sum() / x.len()
+    return 1 - x.is_unique().sum() / x.len()
 
 
 def percent_reoccuring_values(x: TIME_SERIES_T) -> FLOAT_EXPR:
@@ -1175,7 +1176,7 @@ def percent_reoccuring_values(x: TIME_SERIES_T) -> FLOAT_EXPR:
 
     The percentage is calculated as follows:
 
-        len(different values occurring more than once) / len(different values)
+        # (distinct values occurring more than once) / # of distinct values
 
     This means the percentage is normalized to the number of unique values in the time series, in contrast to the
     `percent_reocurring_points` function.
@@ -1293,6 +1294,7 @@ def permutation_entropy(
                 .entropy(base=base, normalize=True)
             )
 
+
 def range_count(
     x: TIME_SERIES_T, lower: float, upper: float, closed: ClosedInterval = "left"
 ) -> INT_EXPR:
@@ -1346,7 +1348,6 @@ def ratio_beyond_r_sigma(x: TIME_SERIES_T, ratio: float = 0.25) -> FLOAT_EXPR:
     )
 
 
-# Originally named `ratio_value_number_to_time_series_length` in tsfresh
 def ratio_n_unique_to_length(x: TIME_SERIES_T) -> FLOAT_EXPR:
     """
     Calculate the ratio of the number of unique values to the length of the time-series.
@@ -1519,7 +1520,18 @@ def sum_reocurring_values(x: TIME_SERIES_T) -> FLOAT_INT_EXPR:
     -------
     float | Expr
     """
-    return x.filter(~x.is_unique()).unique().sum()
+    if isinstance(x, pl.Series):
+        vc = x.value_counts()
+        return vc.filter(
+            pl.col("counts") > 1
+        ).select(
+            pl.col(x.name).sum()
+        ).item(0, 0)
+    else:
+        vc = x.alias("_").value_counts()
+        return vc.filter(
+            vc.struct.field("counts") > 1
+        ).struct.field("_").sum()
 
 
 def symmetry_looking(x: TIME_SERIES_T, ratio: float = 0.25) -> BOOL_EXPR:
@@ -1565,7 +1577,6 @@ def time_reversal_asymmetry_statistic(x: TIME_SERIES_T, n_lags: int) -> FLOAT_EX
     """
     one_lag = x.shift(-n_lags)
     two_lag = x.shift(-2 * n_lags)
-    # We don't need to do .head() here because nulls won't affect mean calculation
     return (one_lag * (two_lag + x) * (two_lag - x)).mean()
 
 
@@ -1731,7 +1742,7 @@ def longest_streak_above(x: TIME_SERIES_T, threshold: float) -> TIME_SERIES_T:
     -------
     float | Expr
     """
-    
+
     y = (x.diff() >= threshold).rle()
     if isinstance(x, pl.Series):
         streak_max = y.filter(y.struct.field("values")).struct.field("lengths").max()

--- a/tests/test_tsfresh.py
+++ b/tests/test_tsfresh.py
@@ -803,27 +803,27 @@ def test_benford_correlation():
 
     X_fibo_lazy = pl.LazyFrame({"a": l_fibo})
     assert_frame_equal(
-        X_uniform.select(benford_correlation(pl.col("a"))),
+        X_uniform.select(benford_correlation(pl.col("a")).alias("counts")),
         pl.DataFrame({"counts": [np.nan]}),
     )
     assert_frame_equal(
-        X_uniform_lazy.select(benford_correlation(pl.col("a"))).collect(),
+        X_uniform_lazy.select(benford_correlation(pl.col("a")).alias("counts")).collect(),
         pl.DataFrame({"counts": [np.nan]}),
     )
     assert_frame_equal(
-        X_random.select(benford_correlation(pl.col("a"))),
+        X_random.select(benford_correlation(pl.col("a")).alias("counts")),
         pl.DataFrame({"counts": [0.39753280229716703]}),
     )
     assert_frame_equal(
-        X_random_lazy.select(benford_correlation(pl.col("a"))).collect(),
+        X_random_lazy.select(benford_correlation(pl.col("a")).alias("counts")).collect(),
         pl.DataFrame({"counts": [0.39753280229716703]}),
     )
     assert_frame_equal(
-        X_fibo.select(benford_correlation(pl.col("a"))),
+        X_fibo.select(benford_correlation(pl.col("a")).alias("counts")),
         pl.DataFrame({"counts": [0.9959632739083689]}),
     )
     assert_frame_equal(
-        X_fibo_lazy.select(benford_correlation(pl.col("a"))).collect(),
+        X_fibo_lazy.select(benford_correlation(pl.col("a")).alias("counts")).collect(),
         pl.DataFrame({"counts": [0.9959632739083689]}),
     )
 

--- a/tests/test_tsfresh.py
+++ b/tests/test_tsfresh.py
@@ -44,8 +44,8 @@ from functime.feature_extraction.tsfresh import (
     mean_second_derivative_central,
     number_crossings,
     number_peaks,
-    percent_reoccuring_values,
-    percent_reocurring_points,
+    percent_reoccurring_values,
+    percent_reoccurring_points,
     permutation_entropy,
     range_change,
     range_count,
@@ -54,8 +54,8 @@ from functime.feature_extraction.tsfresh import (
     ratio_n_unique_to_length,
     root_mean_square,
     sample_entropy,
-    sum_reocurring_points,
-    sum_reocurring_values,
+    sum_reoccurring_points,
+    sum_reoccurring_values,
     symmetry_looking,
     time_reversal_asymmetry_statistic,
     var_gt_std,
@@ -1032,12 +1032,12 @@ def test_mean_n_absolute_max_value_error():
 )
 def test_percent_reoccuring_values(S, res):
     assert_frame_equal(
-        pl.DataFrame({"a": S}).select(percent_reoccuring_values(pl.col("a"))),
-        pl.DataFrame(pl.Series("a", res, dtype=pl.Float64)),
+        pl.DataFrame({"a": S}).select(percent_reoccurring_values(pl.col("a"))),
+        pl.DataFrame(pl.Series("literal", res, dtype=pl.Float64)),
     )
     assert_frame_equal(
-        pl.LazyFrame({"a": S}).select(percent_reoccuring_values(pl.col("a"))).collect(),
-        pl.DataFrame(pl.Series("a", res, dtype=pl.Float64)),
+        pl.LazyFrame({"a": S}).select(percent_reoccurring_values(pl.col("a"))).collect(),
+        pl.DataFrame(pl.Series("literal", res, dtype=pl.Float64)),
     )
 
 
@@ -1052,11 +1052,11 @@ def test_percent_reoccuring_values(S, res):
 )
 def test_percent_reoccuring_values(S, res):  # noqa
     assert_frame_equal(
-        pl.DataFrame({"a": S}).select(percent_reoccuring_values(pl.col("a"))),
+        pl.DataFrame({"a": S}).select(percent_reoccurring_values(pl.col("a"))),
         pl.DataFrame(pl.Series("a", res, dtype=pl.Float64)),
     )
     assert_frame_equal(
-        pl.LazyFrame({"a": S}).select(percent_reoccuring_values(pl.col("a"))).collect(),
+        pl.LazyFrame({"a": S}).select(percent_reoccurring_values(pl.col("a"))).collect(),
         pl.DataFrame(pl.Series("a", res, dtype=pl.Float64)),
     )
 
@@ -1072,11 +1072,11 @@ def test_percent_reoccuring_values(S, res):  # noqa
 )
 def test_sum_reocurring_points(S, res):
     assert_frame_equal(
-        pl.DataFrame({"a": S}).select(sum_reocurring_points(pl.col("a"))),
+        pl.DataFrame({"a": S}).select(sum_reoccurring_points(pl.col("a"))),
         pl.DataFrame(pl.Series("a", res)),
     )
     assert_frame_equal(
-        pl.LazyFrame({"a": S}).select(sum_reocurring_points(pl.col("a"))).collect(),
+        pl.LazyFrame({"a": S}).select(sum_reoccurring_points(pl.col("a"))).collect(),
         pl.DataFrame(pl.Series("a", res)),
     )
 
@@ -1092,11 +1092,11 @@ def test_sum_reocurring_points(S, res):
 )
 def test_sum_reocurring_values(S, res):
     assert_frame_equal(
-        pl.DataFrame({"a": S}).select(sum_reocurring_values(pl.col("a"))),
+        pl.DataFrame({"a": S}).select(sum_reoccurring_values(pl.col("a"))),
         pl.DataFrame(pl.Series("a", res)),
     )
     assert_frame_equal(
-        pl.LazyFrame({"a": S}).select(sum_reocurring_values(pl.col("a"))).collect(),
+        pl.LazyFrame({"a": S}).select(sum_reoccurring_values(pl.col("a"))).collect(),
         pl.DataFrame(pl.Series("a", res)),
     )
 
@@ -1113,12 +1113,12 @@ def test_sum_reocurring_values(S, res):
 )
 def test_percent_reocurring_points(S, res):
     assert_frame_equal(
-        pl.DataFrame({"a": S}).select(percent_reocurring_points(pl.col("a"))),
-        pl.DataFrame(pl.Series("a", res, dtype=pl.Float64)),
+        pl.DataFrame({"a": S}).select(percent_reoccurring_points(pl.col("a"))),
+        pl.DataFrame(pl.Series("literal", res, dtype=pl.Float64)),
     )
     assert_frame_equal(
-        pl.LazyFrame({"a": S}).select(percent_reocurring_points(pl.col("a"))).collect(),
-        pl.DataFrame(pl.Series("a", res, dtype=pl.Float64)),
+        pl.LazyFrame({"a": S}).select(percent_reoccurring_points(pl.col("a"))).collect(),
+        pl.DataFrame(pl.Series("literal", res, dtype=pl.Float64)),
     )
 
 


### PR DESCRIPTION
- More optimizations for features that do not require NumPy / SciPy)

1. Benford Correlation is once again slightly faster now because I replaced value_counts by unique_counts. By putting pl.int_range(1, 10) in front, we do not need to sort, and unique_counts counts in the given order. In addition, unique counts is just slightly faster than value_counts because it only counts and does not return the corresponding values.
2. Number Crossing. Simplified the computation and got a significant speed boost.
3. percent_reoccurring_points,. Simplified the mathematical formula.
4. sum_reoccurring_values. The original one-line implementation was elegant, but is_unique, unique, and filter are more expensive. We can directly do a group_by (value_counts), which cuts down the size of the series, and then filter.. This is 40-50% faster both when there are lots of unique values and when there are almost no unique values.

- Clean Up and Docs
1. Some features will return a column called "literal" in lazy mode. I fixed that in tests. In the name space, we should add suffix.
2. Cleaned up docstrings here and there.