### PR TITLE
Restore M4 daily train data with git lfs

### DIFF
--- a/data/m4_1d_train.parquet
+++ b/data/m4_1d_train.parquet
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2a852a95b2bc5802aa86c2b65b966f2ff1fbbd329f8609ecaaf8c03e4129ade5
+size 74367996


### PR DESCRIPTION
Unfortunately the M4 data was [added to the repo](https://github.com/neocortexdb/functime/blob/d0f8918a64456ef1811e519fe9c0e302225e88c7/data/m4_1d_train.parquet) (not git LFS). This PR removes it from the repo and re-adds it as a git lfs pointer.

Still to do:

1. This does not remove that object from the git history - should use [git filter-repo](https://github.com/newren/git-filter-repo#how-do-i-use-it) to remove it.
2. We can configure a pre-commit builtin hook to avoid committing [files that are too big](https://github.com/pre-commit/pre-commit-hooks#check-added-large-files). Can do that in #108 too. If that's the case, we should agree on a filesize.